### PR TITLE
feat: add HTTP feed ingestion with scheduler loop

### DIFF
--- a/infra/db/init/01_schema.sql
+++ b/infra/db/init/01_schema.sql
@@ -24,7 +24,8 @@ CREATE TABLE IF NOT EXISTS events (
   geom geography,
   jurisdiction TEXT,
   confidence REAL,
-  severity REAL
+  severity REAL,
+  UNIQUE (source_id, title, occurred_at)
 );
 
 CREATE TYPE entity_type AS ENUM (

--- a/ingest/ingest/adapters/http_json_feed.py
+++ b/ingest/ingest/adapters/http_json_feed.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import List, Tuple, Any
+from urllib import request
+
+from ..common.schemas import RawPayload, NormalizedEvent
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_feed(url: str | None = None) -> RawPayload:
+    """Fetch JSON/GeoJSON payload from the configured URL."""
+    feed_url = url or os.getenv("FEED_URL")
+    if not feed_url:
+        raise SystemExit("FEED_URL not set")
+    with request.urlopen(feed_url) as resp:  # nosec - feed url is trusted via env
+        data = json.load(resp)
+    # write raw payload to stdout
+    print(json.dumps(data))
+    return RawPayload(source_name=feed_url, fetched_at=datetime.utcnow(), url=feed_url, content=data)
+
+
+def _extract_items(data: Any) -> List[Any]:
+    if isinstance(data, dict):
+        if data.get("type") == "FeatureCollection" and isinstance(data.get("features"), list):
+            return data["features"]
+        for key in ("items", "incidents", "events"):
+            val = data.get(key)
+            if isinstance(val, list):
+                return val
+        return [data]
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def normalize(raw: RawPayload) -> List[NormalizedEvent]:
+    items = _extract_items(raw.content)
+    events: List[NormalizedEvent] = []
+    for it in items:
+        try:
+            props = it.get("properties", it) if isinstance(it, dict) else {}
+            title = props.get("title") or props.get("name") or props.get("id") or "Event"
+            body = props.get("description") or props.get("summary")
+            occurred = props.get("occurred_at") or props.get("time")
+            occurred_dt = None
+            if occurred:
+                try:
+                    occurred_dt = datetime.fromisoformat(occurred)
+                except Exception:
+                    occurred_dt = None
+            lat = props.get("lat")
+            lon = props.get("lon")
+            geom = it.get("geometry") if isinstance(it, dict) else None
+            if (lat is None or lon is None) and isinstance(geom, dict) and geom.get("type") == "Point":
+                coords = geom.get("coordinates")
+                if isinstance(coords, (list, tuple)) and len(coords) >= 2:
+                    lon, lat = coords[0], coords[1]
+            events.append(
+                NormalizedEvent(
+                    title=title,
+                    body=body,
+                    event_type=props.get("event_type") or "Other",
+                    occurred_at=occurred_dt,
+                    jurisdiction=props.get("jurisdiction"),
+                    confidence=props.get("confidence"),
+                    severity=props.get("severity"),
+                    lat=lat,
+                    lon=lon,
+                    attrs={
+                        k: v
+                        for k, v in props.items()
+                        if k
+                        not in {
+                            "title",
+                            "name",
+                            "id",
+                            "description",
+                            "summary",
+                            "occurred_at",
+                            "time",
+                            "lat",
+                            "lon",
+                            "event_type",
+                            "jurisdiction",
+                            "confidence",
+                            "severity",
+                        }
+                    },
+                )
+            )
+        except Exception as exc:
+            logger.warning("Skipping row: %s", exc)
+    return events
+
+
+def get_source_meta(url: str | None = None) -> Tuple[str, str, str]:
+    feed_url = url or os.getenv("FEED_URL", "")
+    return "HTTP JSON Feed", feed_url, "Other"
+

--- a/ingest/ingest/run.py
+++ b/ingest/ingest/run.py
@@ -1,20 +1,27 @@
 import argparse
+import os
+import time
 from datetime import datetime
-from typing import List
+from typing import List, Tuple
 
 from .common.schemas import NormalizedEvent
 from .common import db as dbmod
 
 
-def run_adapter(name: str) -> List[NormalizedEvent]:
+def run_adapter(name: str, feed_url: str | None = None) -> Tuple[List[NormalizedEvent], str, str, str]:
     if name == "au_wildfire_fixture":
         from .adapters import au_wildfire_fixture as adapter
+        raw = adapter.load_fixture()
+        source_name, source_url, source_type = adapter.get_source_meta()
+    elif name == "http_json_feed":
+        from .adapters import http_json_feed as adapter
+        raw = adapter.fetch_feed(feed_url)
+        source_name, source_url, source_type = adapter.get_source_meta(feed_url)
     else:
         raise SystemExit(f"Unknown adapter: {name}")
 
-    raw = adapter.load_fixture()
     events = adapter.normalize(raw)
-    return events
+    return events, source_name, source_url, source_type
 
 
 def persist(events: List[NormalizedEvent], source_name: str, source_url: str, source_type: str) -> int:
@@ -23,44 +30,92 @@ def persist(events: List[NormalizedEvent], source_name: str, source_url: str, so
         with conn.cursor() as cur:
             source_id = dbmod.ensure_source(cur, source_name, source_url, source_type)
             for ev in events:
-                dbmod.insert_event(
-                    cur,
-                    source_id=source_id,
-                    title=ev.title,
-                    body=ev.body,
-                    event_type=ev.event_type,
-                    occurred_at=ev.occurred_at.isoformat() if ev.occurred_at else None,
-                    lat=ev.lat,
-                    lon=ev.lon,
-                    jurisdiction=ev.jurisdiction,
-                    confidence=ev.confidence,
-                    severity=ev.severity,
-                )
-                count += 1
+                geom_wkt = None
+                if ev.lat is not None and ev.lon is not None:
+                    geom_wkt = f"POINT({ev.lon} {ev.lat})"
+                if geom_wkt:
+                    cur.execute(
+                        """
+                        INSERT INTO events
+                          (source_id, title, body, event_type, occurred_at, detected_at, geom, jurisdiction, confidence, severity)
+                        VALUES
+                          (%s,%s,%s,%s::event_type,%s, now(), ST_GeogFromText(%s), %s, %s, %s)
+                        ON CONFLICT (source_id, title, occurred_at) DO NOTHING
+                        RETURNING id
+                        """,
+                        (
+                            source_id,
+                            ev.title,
+                            ev.body,
+                            ev.event_type,
+                            ev.occurred_at.isoformat() if ev.occurred_at else None,
+                            geom_wkt,
+                            ev.jurisdiction,
+                            ev.confidence,
+                            ev.severity,
+                        ),
+                    )
+                else:
+                    cur.execute(
+                        """
+                        INSERT INTO events
+                          (source_id, title, body, event_type, occurred_at, detected_at, jurisdiction, confidence, severity)
+                        VALUES
+                          (%s,%s,%s,%s::event_type,%s, now(), %s, %s, %s)
+                        ON CONFLICT (source_id, title, occurred_at) DO NOTHING
+                        RETURNING id
+                        """,
+                        (
+                            source_id,
+                            ev.title,
+                            ev.body,
+                            ev.event_type,
+                            ev.occurred_at.isoformat() if ev.occurred_at else None,
+                            ev.jurisdiction,
+                            ev.confidence,
+                            ev.severity,
+                        ),
+                    )
+                if cur.fetchone():
+                    count += 1
         conn.commit()
     return count
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Run an ingestion adapter once")
-    parser.add_argument("--adapter", default="au_wildfire_fixture", help="Adapter name")
+    parser = argparse.ArgumentParser(description="Run an ingestion adapter")
+    parser.add_argument(
+        "--adapter",
+        default=os.getenv("INGEST_ADAPTER", "au_wildfire_fixture"),
+        help="Adapter name",
+    )
+    parser.add_argument("--loop", action="store_true", help="Run continuously")
+    parser.add_argument("--feed-url", default=os.getenv("FEED_URL"), help="Override feed URL")
     args = parser.parse_args()
 
-    if args.adapter == "au_wildfire_fixture":
-        from .adapters import au_wildfire_fixture as adapter
-    else:
-        raise SystemExit(f"Unknown adapter: {args.adapter}")
+    interval = int(os.getenv("INGEST_INTERVAL_SECONDS", "300"))
 
-    raw = adapter.load_fixture()
-    events = adapter.normalize(raw)
-    source_name, source_url, source_type = adapter.get_source_meta()
-    inserted = persist(events, source_name, source_url, source_type)
-    print({
-        "adapter": args.adapter,
-        "fetched_at": datetime.utcnow().isoformat(),
-        "events_normalized": len(events),
-        "events_inserted": inserted,
-    })
+    def run_once() -> None:
+        events, source_name, source_url, source_type = run_adapter(args.adapter, args.feed_url)
+        inserted = persist(events, source_name, source_url, source_type)
+        print(
+            {
+                "adapter": args.adapter,
+                "fetched_at": datetime.utcnow().isoformat(),
+                "events_normalized": len(events),
+                "events_inserted": inserted,
+            }
+        )
+
+    if args.loop:
+        while True:
+            started = datetime.utcnow()
+            run_once()
+            duration = (datetime.utcnow() - started).total_seconds()
+            print({"cycle_complete": datetime.utcnow().isoformat(), "duration_seconds": duration})
+            time.sleep(interval)
+    else:
+        run_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add http_json_feed adapter to fetch and normalize JSON/GeoJSON payloads
- extend ingestion runner with env-configured adapter selection, loop mode, and dedup via ON CONFLICT
- enforce source/title/occurred_at uniqueness in events table

## Testing
- `python -m py_compile ingest/ingest/run.py ingest/ingest/adapters/http_json_feed.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b12437f3a0832cba7860cb5e5ef710