### PR TITLE
Add API and frontend smoke tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.5.4",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "@playwright/test": "^1.45.0"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 60_000,
+  webServer: {
+    command: 'npm run preview',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:5173',
+    headless: true,
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+const mockEvent = {
+  id: 1,
+  title: 'Test Event',
+  event_type: 'Other',
+  source_name: 'Test Source',
+  detected_at: '2024-01-01T00:00:00Z',
+  lon: 151,
+  lat: -33
+};
+
+const mockGeoJSON = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [mockEvent.lon, mockEvent.lat] },
+      properties: { id: mockEvent.id, title: mockEvent.title, event_type: mockEvent.event_type, detected_at: mockEvent.detected_at }
+    }
+  ],
+  count: 1
+};
+
+test('page loads and refresh populates results', async ({ page }) => {
+  await page.route(/\/sources/, route => route.fulfill({ json: { results: [{id:1,name:'Test Source'}] } }));
+  await page.route(/\/events\/geojson/, route => route.fulfill({ json: mockGeoJSON }));
+  await page.route(/\/search/, route => route.fulfill({ json: { results: [mockEvent] } }));
+
+  await page.goto('/');
+
+  await expect(page.getByText('Aussie Open Intel')).toBeVisible();
+  await expect(page.locator('canvas')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await expect(page.getByText('Test Event')).toBeVisible();
+});

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -108,7 +108,7 @@ async def search(
     }
 
 
-@app.get("/events/{event_id}")
+@app.get("/events/{event_id:int}")
 async def get_event(event_id: int, debug_geom: int = 0):
     if debug_geom:
         row = fetch_one(

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "aoi-api"
+version = "0.1.0"
+
+[tool.pytest.ini_options]
+pythonpath = ["app"]

--- a/services/api/tests/test_api.py
+++ b/services/api/tests/test_api.py
@@ -1,0 +1,58 @@
+import os
+import psycopg
+from fastapi.testclient import TestClient
+from app.main import app
+
+# ensure tests use local PostgreSQL
+os.environ.setdefault("DATABASE_URL", "postgresql://aoidb:aoidb@localhost:5432/aoidb")
+
+client = TestClient(app)
+
+def setup_module(_):
+    """Insert a sample source and event for API tests."""
+    dsn = os.environ["DATABASE_URL"]
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute("INSERT INTO sources (name) VALUES ('Test Source') RETURNING id")
+            source_id = cur.fetchone()[0]
+            cur.execute(
+                """
+                INSERT INTO events (source_id, title, body, event_type, occurred_at, detected_at, geom)
+                VALUES (%s, %s, %s, 'Other', now(), now(),
+                        ST_GeogFromText('POINT(151 -33)')) RETURNING id
+                """,
+                (source_id, 'Test Event', 'Body'),
+            )
+            conn.commit()
+
+def teardown_module(_):
+    dsn = os.environ["DATABASE_URL"]
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM events")
+            cur.execute("DELETE FROM sources")
+            conn.commit()
+
+def test_health():
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+def test_recent_events():
+    resp = client.get("/events/recent")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(r["title"] == "Test Event" for r in data["results"])
+
+def test_search():
+    resp = client.get("/search", params={"q": "Test"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(r["title"] == "Test Event" for r in data["results"])
+
+def test_events_geojson():
+    resp = client.get("/events/geojson")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 1
+    assert data["features"][0]["properties"]["title"] == "Test Event"


### PR DESCRIPTION
## Summary
- add regression tests for API endpoints
- add Playwright smoke test for frontend and configuration
- ensure event route only matches integer IDs

## Testing
- `PYTHONPATH=services/api pytest services/api/tests/test_api.py`
- `cd frontend && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_68b1265ee614832cac049adca4b01c77