### PR TITLE
feat(api): enforce auth via bearer header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ MINIO_HOST=minio
 MINIO_PORT=9000
 MINIO_CONSOLE_PORT=9001
 MINIO_BUCKET=raw
+
+# Allow unauthenticated API access (set to 'false' to require Bearer tokens)
+ALLOW_ANON=true

--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ Structure
 Status
 - Phase 0 skeleton with basic API and infra configuration.
 
+Authentication
+--------------
+The API uses a simple bearer token scheme. Provide an `Authorization: Bearer <token>`
+header on requests. Tokens are not yet validated, but the value is attached to the
+structured log context. Set `ALLOW_ANON=false` in the environment to require this
+header; by default anonymous requests are permitted.
+

--- a/services/api/app/auth.py
+++ b/services/api/app/auth.py
@@ -1,32 +1,45 @@
 import os
-from typing import Optional
 
-from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi import HTTPException, Request, status
 from structlog.contextvars import bind_contextvars
 
 
 ALLOW_ANON = os.getenv("ALLOW_ANON", "true").lower() != "false"
-_scheme = HTTPBearer(auto_error=not ALLOW_ANON)
 
 
-def get_current_user(
-    creds: Optional[HTTPAuthorizationCredentials] = Depends(_scheme),
-):
+def get_current_user(request: Request):
     """Return the current user context.
 
-    When ALLOW_ANON is true, requests without credentials are allowed and a
+    Reads the ``Authorization`` header expecting a ``Bearer`` token. When
+    ``ALLOW_ANON`` is true, requests without credentials are allowed and a
     placeholder anonymous user context is returned. Otherwise, a bearer token
     is required but not validated (stub).
     """
-    if creds is None:
+
+    auth_header = request.headers.get("Authorization")
+    if not auth_header:
         if ALLOW_ANON:
             user = {"sub": "anonymous"}
             bind_contextvars(user=user)
             return user
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+        )
 
-    token = creds.credentials
+    try:
+        scheme, token = auth_header.split(" ", 1)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authorization header",
+        )
+
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authorization header",
+        )
+
     # Stub validation: accept any token and return a placeholder user
     user = {"sub": "user", "token": token}
     bind_contextvars(user=user)


### PR DESCRIPTION
## Summary
- parse `Authorization: Bearer` headers to build user context
- allow anonymous requests via `ALLOW_ANON` env flag
- document bearer token usage and flag in README

## Testing
- `cd services/api && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1298427d8832c8305ef480891b45b