### PR TITLE
Add Playwright smoke test and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,15 @@ jobs:
         working-directory: frontend
         run: |
           npm install
+          npx playwright install --with-deps
           npm run build
+
+      - name: Run Playwright tests
+        working-directory: frontend
+        run: |
+          npm run preview &
+          npx wait-on http://localhost:5173
+          npx playwright test
 
       - name: Build Docker images
         run: |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --port 5173 --strictPort"
+    "preview": "vite preview --port 5173 --strictPort",
+    "postinstall": "npx playwright install --with-deps"
   },
   "dependencies": {
     "maplibre-gl": "^4.5.2",
@@ -14,6 +15,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "@vitejs/plugin-react": "^4.3.1",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    baseURL: 'http://localhost:5173'
+  }
+});

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke test', async ({ page }) => {
+  await page.route('**/sources', route => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({ results: [{ id: 1, name: 'Mock Source' }] })
+  }));
+  await page.route('**/events/geojson*', route => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({
+      type: 'FeatureCollection',
+      features: [{
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [150, -33] },
+        properties: { id: 1 }
+      }],
+      count: 1
+    })
+  }));
+  await page.route('**/search*', route => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({
+      results: [{
+        id: 1,
+        title: 'Event 1',
+        event_type: 'fire',
+        source_name: 'Mock Source',
+        detected_at: '2024-01-01T00:00:00Z',
+        lon: 150,
+        lat: -33
+      }]
+    })
+  }));
+
+  await page.goto('/');
+  await page.waitForSelector('.maplibregl-canvas');
+
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await expect(page.getByText('Results (1)')).toBeVisible();
+
+  const canvas = page.locator('.maplibregl-canvas');
+  const before = await canvas.evaluate(el => (el as HTMLCanvasElement).style.transform);
+
+  await page.getByText('Event 1').click();
+  await page.waitForTimeout(500);
+
+  const after = await canvas.evaluate(el => (el as HTMLCanvasElement).style.transform);
+  expect(after).not.toBe(before);
+});


### PR DESCRIPTION
## Summary
- install `@playwright/test` and add postinstall script to fetch browsers
- add Playwright config and smoke test to exercise refresh and map centering
- run Playwright tests in CI after building the frontend

## Testing
- `npm run build`
- `npx playwright test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b12985888c832ca1fba5c883bd8099