### PR TITLE
Add docker-compose integration tests for API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,13 @@ jobs:
         working-directory: services/api
         run: pytest -q
 
+      - name: Run API integration tests
+        run: |
+          cp .env.example .env
+          docker compose -f infra/docker-compose.yml up -d db redis api
+          pytest services/api/tests/test_integration.py -q
+          docker compose -f infra/docker-compose.yml down -v
+
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/services/api/tests/test_integration.py
+++ b/services/api/tests/test_integration.py
@@ -1,0 +1,99 @@
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+ROOT = Path(__file__).resolve().parents[3]
+COMPOSE_FILE = ROOT / "infra" / "docker-compose.yml"
+
+
+def _compose_env() -> dict:
+    env = os.environ.copy()
+    env.update(
+        {
+            "POSTGRES_DB": "aoidb",
+            "POSTGRES_USER": "aoidb",
+            "POSTGRES_PASSWORD": "aoidb",
+            "POSTGRES_PORT": "5432",
+            "REDIS_HOST": "redis",
+            "REDIS_PORT": "6379",
+            "API_PORT": "8000",
+            "MINIO_ROOT_USER": "minioadmin",
+            "MINIO_ROOT_PASSWORD": "minioadmin",
+            "MINIO_BUCKET": "raw",
+        }
+    )
+    return env
+
+
+@pytest.fixture(scope="session")
+def api_base_url():
+    env = _compose_env()
+    subprocess.run(
+        ["docker", "compose", "-f", str(COMPOSE_FILE), "up", "-d", "db", "redis", "api"],
+        check=True,
+        env=env,
+    )
+    base = "http://localhost:8000"
+    for _ in range(60):
+        try:
+            r = requests.get(base + "/health")
+            if r.status_code == 200:
+                break
+        except Exception:
+            pass
+        time.sleep(1)
+    else:
+        raise RuntimeError("API did not become ready in time")
+
+    ingest_env = env.copy()
+    ingest_env["DATABASE_URL"] = "postgresql://aoidb:aoidb@localhost:5432/aoidb"
+    subprocess.run(
+        ["python", "-m", "ingest.run", "--adapter", "au_wildfire_fixture"],
+        check=True,
+        env=ingest_env,
+    )
+
+    yield base
+
+    subprocess.run(
+        ["docker", "compose", "-f", str(COMPOSE_FILE), "down", "-v"],
+        check=True,
+        env=env,
+    )
+
+
+def test_sources(api_base_url):
+    r = requests.get(f"{api_base_url}/sources")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["count"] >= 1
+    assert any(src["name"] == "AU Wildfire Fixture" for src in data["results"])
+
+
+def test_search_and_detail(api_base_url):
+    r = requests.get(f"{api_base_url}/search")
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["results"]) >= 2
+    titles = {e["title"] for e in data["results"]}
+    assert "Grass fire near Toowoomba" in titles
+    event_id = data["results"][0]["id"]
+
+    r2 = requests.get(f"{api_base_url}/events/{event_id}")
+    assert r2.status_code == 200
+    detail = r2.json()
+    assert detail["id"] == event_id
+    assert detail["title"]
+
+
+def test_events_geojson(api_base_url):
+    bbox = "149,-28,153,-25"
+    r = requests.get(f"{api_base_url}/events/geojson?bbox={bbox}")
+    assert r.status_code == 200
+    fc = r.json()
+    assert fc["type"] == "FeatureCollection"
+    assert fc["count"] >= 2


### PR DESCRIPTION
## Summary
- add integration test that spins up PostGIS and API with docker compose, seeds sample events via ingest, and exercises key endpoints
- run integration test in CI after unit tests using docker compose

## Testing
- `pytest services/api/tests/test_api.py -q`
- `pytest services/api/tests/test_integration.py -q` *(fails: [Errno 2] No such file or directory: 'docker')*


------
https://chatgpt.com/codex/tasks/task_e_68b129822660832c8680b79be9d8937d