### PR TITLE
Add structured JSON logging to API and ingest

### DIFF
--- a/ingest/ingest/run.py
+++ b/ingest/ingest/run.py
@@ -114,20 +114,20 @@ def main():
     bind_contextvars(source="ingest", adapter=args.adapter)
 
     def run_once() -> None:
+        started = time.monotonic()
         events, source_name, source_url, source_type = run_adapter(args.adapter, args.feed_url)
         inserted = persist(events, source_name, source_url, source_type)
-        logger.info(
-            "cycle",
+        duration = time.monotonic() - started
+        bind_contextvars(
             events_normalized=len(events),
             events_inserted=inserted,
+            duration_seconds=duration,
         )
+        logger.info("cycle")
 
     if args.loop:
         while True:
-            started = time.monotonic()
             run_once()
-            duration = time.monotonic() - started
-            logger.info("cycle_complete", duration_seconds=duration)
             time.sleep(interval)
     else:
         run_once()

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -5,7 +5,7 @@ import structlog
 from structlog.contextvars import bind_contextvars, clear_contextvars
 from fastapi import FastAPI, Query, HTTPException, Depends, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import ORJSONResponse, JSONResponse
 from typing import Optional, List
 from datetime import datetime
 
@@ -53,6 +53,15 @@ async def add_context(request: Request, call_next):
         status_code=response.status_code,
     )
     return response
+
+
+@app.exception_handler(Exception)
+async def handle_exceptions(request: Request, exc: Exception):
+    logger.error("unhandled_error", error=str(exc))
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal Server Error"},
+    )
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary
- Configure API and ingest services to use structlog with JSON output and timestamps
- Bind request and cycle context fields to structured logs
- Add global API exception handler that logs without stack traces

## Testing
- `PYTHONPATH=services/api pytest -q`
- `python -m py_compile services/api/app/main.py ingest/ingest/run.py`
- `PYTHONPATH=ingest DATABASE_URL=postgresql://localhost:5432/test python -m ingest.run --adapter au_wildfire_fixture` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b12983769c832cb368e1849f204f12