### PR TITLE
feat: add event indexes for query performance

### DIFF
--- a/infra/db/init/01_schema.sql
+++ b/infra/db/init/01_schema.sql
@@ -85,4 +85,7 @@ CREATE INDEX IF NOT EXISTS idx_events_geom ON events USING GIST(geom);
 CREATE INDEX IF NOT EXISTS idx_entities_type_name ON entities(type, name);
 CREATE INDEX IF NOT EXISTS idx_event_entities_event ON event_entities(event_id);
 CREATE INDEX IF NOT EXISTS idx_relations_src_dst ON relations(src_entity, dst_entity);
+CREATE INDEX IF NOT EXISTS idx_events_event_type_detected_at ON events(event_type, detected_at DESC);
+CREATE INDEX IF NOT EXISTS idx_events_source_detected_at ON events(source_id, detected_at DESC);
+CREATE INDEX IF NOT EXISTS idx_events_text_search ON events USING GIN (to_tsvector('simple', title || ' ' || coalesce(body,'')));
 


### PR DESCRIPTION
## Summary
- index events by event_type and detected_at
- index events by source_id and detected_at
- add GIN full-text search index on events

## Testing
- `psql -d aoidb -P pager=off -c '\d events'`
- `psql -d aoidb -c "EXPLAIN SELECT * FROM events WHERE event_type='Weather' ORDER BY detected_at DESC LIMIT 5;"`
- `psql -d aoidb -c "EXPLAIN SELECT * FROM events WHERE source_id=1 ORDER BY detected_at DESC LIMIT 5;"`
- `psql -d aoidb -c "EXPLAIN SELECT * FROM events WHERE to_tsvector('simple', title || ' ' || coalesce(body,'')) @@ plainto_tsquery('simple', 'title1');"`


------
https://chatgpt.com/codex/tasks/task_e_68b12984f470832ca83ef2784e9c55c9