### PR TITLE
Add notebook CRUD, export endpoints, and UI save

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -214,6 +214,22 @@ export default function App() {
     setTimeRange(`${start.toISOString()}..${end.toISOString()}`)
   }
 
+  const saveToNotebook = async (eventId: number) => {
+    const title = window.prompt('Notebook title?')
+    if (!title) return
+    try {
+      await fetch(`${API_BASE}/notebooks`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, items: [{ event: eventId }] })
+      })
+      window.alert('Saved to notebook')
+    } catch (e) {
+      console.error(e)
+      window.alert('Failed to save')
+    }
+  }
+
   // Update selected ring highlight when selection changes
   useEffect(() => {
     const map = mapRef.current
@@ -308,6 +324,12 @@ export default function App() {
                     )}
                   </div>
                   <div style={{ fontSize: 12, color: '#666' }}>{r.detected_at?.replace('T', ' ').replace('Z','')} {r.jurisdiction ? `• ${r.jurisdiction}` : ''}</div>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); saveToNotebook(r.id) }}
+                    style={{ marginTop: 6 }}
+                  >
+                    Save to notebook
+                  </button>
                 </div>
               )
             })}

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -3,13 +3,20 @@ from uuid import uuid4
 
 import structlog
 from structlog.contextvars import bind_contextvars, clear_contextvars
-from fastapi import FastAPI, Query, HTTPException, Depends, Request
+from fastapi import FastAPI, Query, HTTPException, Depends, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse, JSONResponse
 from typing import Optional, List
 from datetime import datetime
 
-from .schemas import Event, Entity, Notebook, SearchQuery
+from .schemas import (
+    Event,
+    Entity,
+    Notebook,
+    NotebookCreate,
+    NotebookUpdate,
+    SearchQuery,
+)
 from .db import fetch_all, fetch_one
 from .auth import get_current_user
 
@@ -210,14 +217,99 @@ async def graph(seed: Optional[int] = Query(default=None, description="Seed enti
 
 
 @app.get("/notebooks/{notebook_id}", response_model=Notebook)
-async def get_notebook(notebook_id: int):
-    return Notebook(id=notebook_id, owner="demo", title="Demo Notebook", items=[{"event": 1}])
+async def get_notebook(notebook_id: int, user: dict = Depends(get_current_user)):
+    row = fetch_one(
+        """
+        SELECT id, owner, title, items, created_at
+        FROM notebooks
+        WHERE id=%s AND owner=%s
+        """,
+        (notebook_id, user.get("sub")),
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Notebook not found")
+    return row
 
 
 @app.post("/notebooks", response_model=Notebook)
-async def create_notebook(nb: Notebook):
-    # Placeholder echo endpoint
-    return nb
+async def create_notebook(nb: NotebookCreate, user: dict = Depends(get_current_user)):
+    row = fetch_one(
+        """
+        INSERT INTO notebooks (owner, title, items)
+        VALUES (%s, %s, %s)
+        RETURNING id, owner, title, items, created_at
+        """,
+        (user.get("sub"), nb.title, nb.items),
+    )
+    return row
+
+
+@app.put("/notebooks/{notebook_id}", response_model=Notebook)
+async def update_notebook(
+    notebook_id: int, nb: NotebookUpdate, user: dict = Depends(get_current_user)
+):
+    row = fetch_one(
+        """
+        UPDATE notebooks
+        SET title = COALESCE(%s, title), items = COALESCE(%s, items)
+        WHERE id=%s AND owner=%s
+        RETURNING id, owner, title, items, created_at
+        """,
+        (nb.title, nb.items, notebook_id, user.get("sub")),
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Notebook not found")
+    return row
+
+
+@app.get("/notebooks/{notebook_id}/export")
+async def export_notebook(
+    notebook_id: int, fmt: str = Query("md", pattern="^(md|markdown|json|pdf)$"), user: dict = Depends(get_current_user)
+):
+    nb = fetch_one(
+        """
+        SELECT id, owner, title, items, created_at
+        FROM notebooks
+        WHERE id=%s AND owner=%s
+        """,
+        (notebook_id, user.get("sub")),
+    )
+    if not nb:
+        raise HTTPException(status_code=404, detail="Notebook not found")
+
+    if fmt in {"json"}:
+        return JSONResponse(nb)
+    if fmt in {"md", "markdown"}:
+        lines = [f"# {nb['title']}", ""]
+        for item in nb.get("items", []):
+            if isinstance(item, dict) and "event" in item:
+                lines.append(f"- Event {item['event']}")
+            else:
+                lines.append(f"- {item}")
+        return Response("\n".join(lines), media_type="text/markdown")
+    if fmt == "pdf":
+        from io import BytesIO
+        from reportlab.pdfgen import canvas
+
+        buf = BytesIO()
+        c = canvas.Canvas(buf)
+        y = 800
+        c.setFont("Helvetica-Bold", 16)
+        c.drawString(40, y, nb["title"])
+        c.setFont("Helvetica", 12)
+        y -= 40
+        for item in nb.get("items", []):
+            text = (
+                f"- Event {item['event']}" if isinstance(item, dict) and "event" in item else f"- {item}"
+            )
+            c.drawString(40, y, text)
+            y -= 20
+        c.showPage()
+        c.save()
+        pdf_bytes = buf.getvalue()
+        buf.close()
+        return Response(content=pdf_bytes, media_type="application/pdf")
+    raise HTTPException(status_code=400, detail="Unsupported format")
 
 
 @app.get("/events/recent")

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -54,6 +54,16 @@ class Notebook(BaseModel):
     created_at: Optional[datetime] = None
 
 
+class NotebookCreate(BaseModel):
+    title: str
+    items: list
+
+
+class NotebookUpdate(BaseModel):
+    title: Optional[str] = None
+    items: Optional[list] = None
+
+
 class SearchQuery(BaseModel):
     q: Optional[str] = None
     bbox: Optional[str] = None

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -7,3 +7,5 @@ typing-extensions>=4.12.2
 psycopg[binary]==3.2.1
 structlog==24.4.0
 PyJWT==2.9.0
+reportlab==4.2.0
+httpx==0.27.0

--- a/services/api/tests/test_notebooks.py
+++ b/services/api/tests/test_notebooks.py
@@ -1,0 +1,44 @@
+import json
+from datetime import datetime
+
+def sample_nb():
+    return {
+        "id": 1,
+        "owner": "anonymous",
+        "title": "Test",
+        "items": [{"event": 2}],
+        "created_at": datetime.utcnow().isoformat()
+    }
+
+def test_notebook_crud(client, mock_fetch_one):
+    mock_fetch_one["result"] = sample_nb()
+    r = client.get("/notebooks/1")
+    assert r.status_code == 200
+    assert mock_fetch_one["calls"][0]["sql"].startswith("\n        SELECT")
+
+    mock_fetch_one["result"] = sample_nb() | {"id": 2, "title": "New"}
+    r = client.post("/notebooks", json={"title": "New", "items": []})
+    assert r.status_code == 200
+    assert mock_fetch_one["calls"][1]["sql"].strip().startswith("INSERT INTO notebooks")
+
+    mock_fetch_one["result"] = sample_nb() | {"title": "Updated"}
+    r = client.put("/notebooks/1", json={"title": "Updated", "items": [{"event": 2}]})
+    assert r.status_code == 200
+    assert mock_fetch_one["calls"][2]["sql"].strip().startswith("UPDATE notebooks")
+
+def test_notebook_export(client, mock_fetch_one):
+    nb = sample_nb()
+    mock_fetch_one["result"] = nb
+    r = client.get("/notebooks/1/export?fmt=md")
+    assert r.status_code == 200
+    assert r.text.startswith("# ")
+
+    mock_fetch_one["result"] = nb
+    r = client.get("/notebooks/1/export?fmt=json")
+    assert r.status_code == 200
+    assert r.json()["title"] == nb["title"]
+
+    mock_fetch_one["result"] = nb
+    r = client.get("/notebooks/1/export?fmt=pdf")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "application/pdf"


### PR DESCRIPTION
## Summary
- implement database-backed notebook create, update, fetch and export (md/json/pdf)
- add simple UI to save events to notebooks
- cover notebook API with CRUD and export tests

## Testing
- `pytest tests/test_api.py tests/test_notebooks.py`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68b13260864c832c9d005f6c4a1cd1fb