### PR TITLE
Add AIS, bushfire, cyber and news ingestion adapters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,11 @@ MINIO_BUCKET=raw
 INGEST_ADAPTER=au_wildfire_fixture
 FEED_URL=
 INGEST_INTERVAL_SECONDS=600
+# Specific feed URLs
+AIS_FEED_URL=
+BUSHFIRE_FEED_URL=
+CYBER_FEED_URL=
+NEWS_FEED_URL=
 
 # Allow unauthenticated API access (set to 'false' to require Bearer tokens)
 ALLOW_ANON=true

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -77,6 +77,10 @@ services:
       INGEST_RUN_ON_START: "true"
       FEED_URL: ${FEED_URL}
       INGEST_INTERVAL_SECONDS: ${INGEST_INTERVAL_SECONDS}
+      AIS_FEED_URL: ${AIS_FEED_URL}
+      BUSHFIRE_FEED_URL: ${BUSHFIRE_FEED_URL}
+      CYBER_FEED_URL: ${CYBER_FEED_URL}
+      NEWS_FEED_URL: ${NEWS_FEED_URL}
     command: ["python", "-m", "ingest.run", "--adapter", "${INGEST_ADAPTER:-au_wildfire_fixture}"]
 
   web:

--- a/ingest/ingest/adapters/__init__.py
+++ b/ingest/ingest/adapters/__init__.py
@@ -1,2 +1,9 @@
-__all__ = []
+__all__ = [
+    "au_wildfire_fixture",
+    "http_json_feed",
+    "ais",
+    "bushfire_alerts",
+    "cyber_advisories",
+    "news_feed",
+]
 

--- a/ingest/ingest/adapters/ais.py
+++ b/ingest/ingest/adapters/ais.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import List, Tuple
+from urllib import request
+
+from ..common import store
+from ..common.schemas import RawPayload, NormalizedEvent
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_feed(url: str | None = None) -> RawPayload:
+    """Fetch AIS positions from configured endpoint."""
+    feed_url = url or os.getenv("AIS_FEED_URL")
+    if not feed_url:
+        raise SystemExit("AIS_FEED_URL not set")
+    req = request.Request(feed_url, headers={"User-Agent": "AOID-Ingest/1.0"})
+    with request.urlopen(req, timeout=20) as resp:  # nosec - url from env
+        data = json.load(resp)
+    key = f"{datetime.utcnow().isoformat()}_payload.json"
+    try:
+        store.put_raw("ais", key, json.dumps(data).encode("utf-8"), "application/json")
+    except Exception as exc:  # pragma: no cover - storage optional
+        logger.warning("Failed to store raw payload: %s", exc)
+    return RawPayload(source_name=feed_url, fetched_at=datetime.utcnow(), url=feed_url, content=data)
+
+
+def normalize(raw: RawPayload) -> List[NormalizedEvent]:
+    items = raw.content.get("vessels", []) if isinstance(raw.content, dict) else []
+    events: List[NormalizedEvent] = []
+    for it in items:
+        try:
+            occurred = it.get("timestamp")
+            occurred_dt = None
+            if occurred:
+                try:
+                    occurred_dt = datetime.fromisoformat(occurred.replace("Z", "+00:00"))
+                except Exception:
+                    occurred_dt = None
+            events.append(
+                NormalizedEvent(
+                    title=it.get("name") or f"Vessel {it.get('mmsi')}",
+                    event_type="VesselPosition",
+                    occurred_at=occurred_dt,
+                    lat=it.get("lat"),
+                    lon=it.get("lon"),
+                    attrs={k: v for k, v in it.items() if k not in {"name", "mmsi", "lat", "lon", "timestamp"}},
+                )
+            )
+        except Exception as exc:
+            logger.warning("Skipping row: %s", exc)
+    return events
+
+
+def get_source_meta(url: str | None = None) -> Tuple[str, str, str]:
+    feed_url = url or os.getenv("AIS_FEED_URL", "")
+    return "AIS Feed", feed_url, "Maritime"

--- a/ingest/ingest/adapters/bushfire_alerts.py
+++ b/ingest/ingest/adapters/bushfire_alerts.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import List, Tuple
+from urllib import request
+
+from ..common import store
+from ..common.schemas import RawPayload, NormalizedEvent
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_feed(url: str | None = None) -> RawPayload:
+    """Fetch bushfire alert data from the configured endpoint."""
+    feed_url = url or os.getenv("BUSHFIRE_FEED_URL")
+    if not feed_url:
+        raise SystemExit("BUSHFIRE_FEED_URL not set")
+    req = request.Request(feed_url, headers={"User-Agent": "AOID-Ingest/1.0"})
+    with request.urlopen(req, timeout=20) as resp:  # nosec - url from env
+        data = json.load(resp)
+    key = f"{datetime.utcnow().isoformat()}_payload.json"
+    try:
+        store.put_raw("bushfire-alerts", key, json.dumps(data).encode("utf-8"), "application/json")
+    except Exception as exc:  # pragma: no cover - storage optional
+        logger.warning("Failed to store raw payload: %s", exc)
+    return RawPayload(source_name=feed_url, fetched_at=datetime.utcnow(), url=feed_url, content=data)
+
+
+def normalize(raw: RawPayload) -> List[NormalizedEvent]:
+    items = raw.content.get("alerts", []) if isinstance(raw.content, dict) else []
+    events: List[NormalizedEvent] = []
+    for it in items:
+        try:
+            occurred = it.get("time")
+            occurred_dt = None
+            if occurred:
+                try:
+                    occurred_dt = datetime.fromisoformat(occurred.replace("Z", "+00:00"))
+                except Exception:
+                    occurred_dt = None
+            events.append(
+                NormalizedEvent(
+                    title=it.get("title") or "Bushfire",
+                    body=it.get("description"),
+                    event_type="Bushfire",
+                    occurred_at=occurred_dt,
+                    jurisdiction=it.get("state") or it.get("jurisdiction"),
+                    confidence=it.get("confidence"),
+                    severity=it.get("severity"),
+                    lat=it.get("lat"),
+                    lon=it.get("lon"),
+                    attrs={
+                        k: v
+                        for k, v in it.items()
+                        if k
+                        not in {
+                            "title",
+                            "description",
+                            "time",
+                            "lat",
+                            "lon",
+                            "severity",
+                            "state",
+                            "jurisdiction",
+                            "confidence",
+                        }
+                    },
+                )
+            )
+        except Exception as exc:
+            logger.warning("Skipping row: %s", exc)
+    return events
+
+
+def get_source_meta(url: str | None = None) -> Tuple[str, str, str]:
+    feed_url = url or os.getenv("BUSHFIRE_FEED_URL", "")
+    return "Bushfire Alerts Feed", feed_url, "Wildfire"

--- a/ingest/ingest/adapters/cyber_advisories.py
+++ b/ingest/ingest/adapters/cyber_advisories.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import List, Tuple
+from urllib import request
+
+from ..common import store
+from ..common.schemas import RawPayload, NormalizedEvent
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_feed(url: str | None = None) -> RawPayload:
+    """Fetch cybersecurity advisories from the configured endpoint."""
+    feed_url = url or os.getenv("CYBER_FEED_URL")
+    if not feed_url:
+        raise SystemExit("CYBER_FEED_URL not set")
+    req = request.Request(feed_url, headers={"User-Agent": "AOID-Ingest/1.0"})
+    with request.urlopen(req, timeout=20) as resp:  # nosec - url from env
+        data = json.load(resp)
+    key = f"{datetime.utcnow().isoformat()}_payload.json"
+    try:
+        store.put_raw("cyber-advisories", key, json.dumps(data).encode("utf-8"), "application/json")
+    except Exception as exc:  # pragma: no cover - storage optional
+        logger.warning("Failed to store raw payload: %s", exc)
+    return RawPayload(source_name=feed_url, fetched_at=datetime.utcnow(), url=feed_url, content=data)
+
+
+def normalize(raw: RawPayload) -> List[NormalizedEvent]:
+    items = raw.content.get("advisories", []) if isinstance(raw.content, dict) else []
+    events: List[NormalizedEvent] = []
+    for it in items:
+        try:
+            occurred = it.get("published") or it.get("date")
+            occurred_dt = None
+            if occurred:
+                try:
+                    occurred_dt = datetime.fromisoformat(occurred.replace("Z", "+00:00"))
+                except Exception:
+                    occurred_dt = None
+            events.append(
+                NormalizedEvent(
+                    title=it.get("title") or "Advisory",
+                    body=it.get("summary"),
+                    event_type="Cybersecurity",
+                    occurred_at=occurred_dt,
+                    severity=it.get("severity"),
+                    attrs={k: v for k, v in it.items() if k not in {"title", "summary", "published", "date", "severity"}},
+                )
+            )
+        except Exception as exc:
+            logger.warning("Skipping row: %s", exc)
+    return events
+
+
+def get_source_meta(url: str | None = None) -> Tuple[str, str, str]:
+    feed_url = url or os.getenv("CYBER_FEED_URL", "")
+    return "Cybersecurity Advisories", feed_url, "Cybersecurity"

--- a/ingest/ingest/adapters/news_feed.py
+++ b/ingest/ingest/adapters/news_feed.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import List, Tuple
+from urllib import request
+from xml.etree import ElementTree as ET
+
+from ..common import store
+from ..common.schemas import RawPayload, NormalizedEvent
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_feed(url: str | None = None) -> RawPayload:
+    """Fetch a news feed in RSS or JSON format."""
+    feed_url = url or os.getenv("NEWS_FEED_URL")
+    if not feed_url:
+        raise SystemExit("NEWS_FEED_URL not set")
+    req = request.Request(feed_url, headers={"User-Agent": "AOID-Ingest/1.0"})
+    with request.urlopen(req, timeout=20) as resp:  # nosec - url from env
+        content = resp.read()
+        ctype = resp.headers.get("Content-Type", "application/octet-stream")
+    key = f"{datetime.utcnow().isoformat()}_payload"
+    try:
+        store.put_raw("news-feed", key, content, ctype)
+    except Exception as exc:  # pragma: no cover - storage optional
+        logger.warning("Failed to store raw payload: %s", exc)
+    text = content.decode("utf-8", errors="ignore")
+    try:
+        data = json.loads(text)
+    except Exception:
+        data = text
+    return RawPayload(source_name=feed_url, fetched_at=datetime.utcnow(), url=feed_url, content=data)
+
+
+def normalize(raw: RawPayload) -> List[NormalizedEvent]:
+    if isinstance(raw.content, str):
+        try:
+            root = ET.fromstring(raw.content)
+        except Exception:
+            return []
+        items = root.findall(".//item")
+        events: List[NormalizedEvent] = []
+        for it in items:
+            title = it.findtext("title") or "News"
+            body = it.findtext("description")
+            pub = it.findtext("pubDate")
+            occurred_dt = None
+            if pub:
+                for fmt in ["%a, %d %b %Y %H:%M:%S %Z", "%Y-%m-%dT%H:%M:%SZ"]:
+                    try:
+                        occurred_dt = datetime.strptime(pub, fmt)
+                        break
+                    except Exception:
+                        continue
+            events.append(NormalizedEvent(title=title, body=body, event_type="News", occurred_at=occurred_dt))
+        return events
+    else:
+        items = raw.content.get("items", []) if isinstance(raw.content, dict) else []
+        events: List[NormalizedEvent] = []
+        for it in items:
+            occurred = it.get("published") or it.get("date")
+            occurred_dt = None
+            if occurred:
+                try:
+                    occurred_dt = datetime.fromisoformat(occurred.replace("Z", "+00:00"))
+                except Exception:
+                    occurred_dt = None
+            events.append(
+                NormalizedEvent(
+                    title=it.get("title") or "News",
+                    body=it.get("summary"),
+                    event_type="News",
+                    occurred_at=occurred_dt,
+                    attrs={k: v for k, v in it.items() if k not in {"title", "summary", "published", "date"}},
+                )
+            )
+        return events
+
+
+def get_source_meta(url: str | None = None) -> Tuple[str, str, str]:
+    feed_url = url or os.getenv("NEWS_FEED_URL", "")
+    return "News Feed", feed_url, "News"

--- a/ingest/ingest/fixtures/ais_sample.json
+++ b/ingest/ingest/fixtures/ais_sample.json
@@ -1,0 +1,12 @@
+{
+  "vessels": [
+    {
+      "mmsi": "123456789",
+      "name": "Test Vessel",
+      "lat": -33.86,
+      "lon": 151.2,
+      "timestamp": "2024-01-01T00:00:00Z",
+      "speed": 12.3
+    }
+  ]
+}

--- a/ingest/ingest/fixtures/bushfire_alerts_sample.json
+++ b/ingest/ingest/fixtures/bushfire_alerts_sample.json
@@ -1,0 +1,13 @@
+{
+  "alerts": [
+    {
+      "title": "Bushfire near Sydney",
+      "description": "Test bushfire",
+      "time": "2024-01-01T01:00:00Z",
+      "lat": -33.9,
+      "lon": 151.2,
+      "severity": 0.7,
+      "state": "NSW"
+    }
+  ]
+}

--- a/ingest/ingest/fixtures/cyber_advisories_sample.json
+++ b/ingest/ingest/fixtures/cyber_advisories_sample.json
@@ -1,0 +1,10 @@
+{
+  "advisories": [
+    {
+      "title": "CVE-2024-1234",
+      "summary": "Test vulnerability",
+      "published": "2024-01-02T00:00:00Z",
+      "severity": 5.0
+    }
+  ]
+}

--- a/ingest/ingest/fixtures/news_feed_sample.xml
+++ b/ingest/ingest/fixtures/news_feed_sample.xml
@@ -1,0 +1,10 @@
+<rss version="2.0">
+  <channel>
+    <title>Sample News</title>
+    <item>
+      <title>News Item</title>
+      <description>News description</description>
+      <pubDate>Tue, 02 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/ingest/ingest/run.py
+++ b/ingest/ingest/run.py
@@ -21,6 +21,22 @@ def run_adapter(name: str, feed_url: str | None = None) -> Tuple[List[Normalized
         from .adapters import http_json_feed as adapter
         raw = adapter.fetch_feed(feed_url)
         source_name, source_url, source_type = adapter.get_source_meta(feed_url)
+    elif name == "ais":
+        from .adapters import ais as adapter
+        raw = adapter.fetch_feed(feed_url)
+        source_name, source_url, source_type = adapter.get_source_meta(feed_url)
+    elif name == "bushfire_alerts":
+        from .adapters import bushfire_alerts as adapter
+        raw = adapter.fetch_feed(feed_url)
+        source_name, source_url, source_type = adapter.get_source_meta(feed_url)
+    elif name == "cyber_advisories":
+        from .adapters import cyber_advisories as adapter
+        raw = adapter.fetch_feed(feed_url)
+        source_name, source_url, source_type = adapter.get_source_meta(feed_url)
+    elif name == "news_feed":
+        from .adapters import news_feed as adapter
+        raw = adapter.fetch_feed(feed_url)
+        source_name, source_url, source_type = adapter.get_source_meta(feed_url)
     else:
         raise SystemExit(f"Unknown adapter: {name}")
 

--- a/ingest/tests/test_adapters.py
+++ b/ingest/tests/test_adapters.py
@@ -1,0 +1,109 @@
+import json
+import pathlib
+import sys
+from datetime import datetime
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from ingest.common.schemas import RawPayload
+from ingest import run
+from ingest.adapters import (
+    ais,
+    bushfire_alerts,
+    cyber_advisories,
+    news_feed,
+)
+
+
+class FakeCursor:
+    def __init__(self):
+        self._fetch = None
+        self.last_id = 0
+
+    def execute(self, query, params):
+        q = query.strip()
+        if q.startswith("SELECT id FROM sources"):
+            self._fetch = (1,)
+        elif q.startswith("INSERT INTO sources"):
+            self._fetch = (1,)
+        elif q.startswith("INSERT INTO events"):
+            self.last_id += 1
+            self._fetch = (self.last_id,)
+        else:
+            self._fetch = None
+
+    def fetchone(self):
+        return self._fetch
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+class FakeConn:
+    def cursor(self):
+        return FakeCursor()
+
+    def commit(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+def fake_get_conn():
+    return FakeConn()
+
+
+def load_fixture(name: str):
+    path = pathlib.Path(__file__).resolve().parents[1] / "ingest" / "fixtures" / name
+    with open(path, "r", encoding="utf-8") as f:
+        if name.endswith(".xml"):
+            return f.read()
+        return json.load(f)
+
+
+def _persist(events, meta):
+    run.dbmod.get_conn = fake_get_conn
+    return run.persist(events, *meta)
+
+
+def test_ais_adapter_normalizes_and_persists():
+    data = load_fixture("ais_sample.json")
+    raw = RawPayload(source_name="test", fetched_at=datetime.utcnow(), url="http://example", content=data)
+    events = ais.normalize(raw)
+    assert events
+    count = _persist(events, ais.get_source_meta("http://example"))
+    assert count == len(events)
+
+
+def test_bushfire_adapter_normalizes_and_persists():
+    data = load_fixture("bushfire_alerts_sample.json")
+    raw = RawPayload(source_name="test", fetched_at=datetime.utcnow(), url="http://example", content=data)
+    events = bushfire_alerts.normalize(raw)
+    assert events
+    count = _persist(events, bushfire_alerts.get_source_meta("http://example"))
+    assert count == len(events)
+
+
+def test_cyber_adapter_normalizes_and_persists():
+    data = load_fixture("cyber_advisories_sample.json")
+    raw = RawPayload(source_name="test", fetched_at=datetime.utcnow(), url="http://example", content=data)
+    events = cyber_advisories.normalize(raw)
+    assert events
+    count = _persist(events, cyber_advisories.get_source_meta("http://example"))
+    assert count == len(events)
+
+
+def test_news_adapter_normalizes_and_persists():
+    data = load_fixture("news_feed_sample.xml")
+    raw = RawPayload(source_name="test", fetched_at=datetime.utcnow(), url="http://example", content=data)
+    events = news_feed.normalize(raw)
+    assert events
+    count = _persist(events, news_feed.get_source_meta("http://example"))
+    assert count == len(events)


### PR DESCRIPTION
## Summary
- add adapters for AIS, bushfire alerts, cybersecurity advisories and news feeds
- wire adapters into ingest runner with env config and docker compose
- include fixtures and smoke tests for normalization and persistence

## Testing
- `pytest ingest/tests/test_adapters.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1325dea04832cb6083387106c3aa1