### PR TITLE
Add BOM Queensland warnings adapter

### DIFF
--- a/ingest/ingest/adapters/__init__.py
+++ b/ingest/ingest/adapters/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "cyber_advisories",
     "acsc_adapter",
     "news_feed",
+    "bom_warnings_adapter",
     "bom",
     "qfes",
 ]

--- a/ingest/ingest/adapters/bom_warnings_adapter.py
+++ b/ingest/ingest/adapters/bom_warnings_adapter.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from typing import List, Tuple
+from urllib import request
+from xml.etree import ElementTree as ET
+
+from ..common import store
+from ..common.schemas import RawPayload, NormalizedEvent
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_feed(url: str | None = None) -> RawPayload:
+    """Fetch BOM Queensland warnings feed."""
+    feed_url = url or os.getenv("BOM_QLD_WARNINGS_URL")
+    if not feed_url:
+        raise SystemExit("BOM_QLD_WARNINGS_URL not set")
+    req = request.Request(feed_url, headers={"User-Agent": "AOID-Ingest/1.0"})
+    with request.urlopen(req, timeout=20) as resp:  # nosec - URL from env
+        content = resp.read()
+        ctype = resp.headers.get("Content-Type", "application/octet-stream")
+    key = f"{datetime.utcnow().isoformat()}_payload.xml"
+    try:
+        store.put_raw("bom-warnings", key, content, ctype)
+    except Exception as exc:  # pragma: no cover - optional
+        logger.warning("Failed to store raw payload: %s", exc)
+    text = content.decode("utf-8", errors="ignore")
+    return RawPayload(source_name=feed_url, fetched_at=datetime.utcnow(), url=feed_url, content=text)
+
+
+def normalize(raw: RawPayload) -> List[NormalizedEvent]:
+    try:
+        root = ET.fromstring(raw.content)
+    except Exception:
+        return []
+    events: List[NormalizedEvent] = []
+    for warn in root.findall(".//warning"):
+        title = warn.findtext("title") or "BOM Warning"
+        desc = warn.findtext("description")
+        issued = warn.findtext("issued")
+        area = warn.findtext("area")
+        occurred_dt = None
+        if issued:
+            try:
+                occurred_dt = datetime.fromisoformat(issued.replace("Z", "+00:00"))
+            except Exception:
+                pass
+        events.append(
+            NormalizedEvent(
+                title=title,
+                body=desc,
+                event_type="Weather",
+                occurred_at=occurred_dt,
+                jurisdiction=area,
+            )
+        )
+    return events
+
+
+def get_source_meta(url: str | None = None) -> Tuple[str, str, str]:
+    feed_url = url or os.getenv("BOM_QLD_WARNINGS_URL", "")
+    return "BOM Queensland Warnings", feed_url, "Weather"

--- a/ingest/ingest/fixtures/bom_warnings_sample.xml
+++ b/ingest/ingest/fixtures/bom_warnings_sample.xml
@@ -1,0 +1,8 @@
+<warnings>
+  <warning>
+    <title>Severe Thunderstorm Warning for parts of South East Queensland</title>
+    <description>Large hailstones and damaging winds possible.</description>
+    <issued>2024-06-01T11:00:00+10:00</issued>
+    <area>South East Queensland</area>
+  </warning>
+</warnings>

--- a/ingest/tests/test_adapters.py
+++ b/ingest/tests/test_adapters.py
@@ -27,6 +27,7 @@ from ingest.adapters import (
     bushfire_alerts,
     cyber_advisories,
     acsc_adapter,
+    bom_warnings_adapter,
     news_feed,
 )
 
@@ -131,4 +132,15 @@ def test_acsc_adapter_normalizes_and_persists():
     events = acsc_adapter.normalize(raw)
     assert events
     count = _persist(events, acsc_adapter.get_source_meta("http://example"))
+    assert count == len(events)
+
+
+def test_bom_warnings_adapter_normalizes_and_persists():
+    data = load_fixture("bom_warnings_sample.xml")
+    raw = RawPayload(source_name="test", fetched_at=datetime.utcnow(), url="http://example", content=data)
+    events = bom_warnings_adapter.normalize(raw)
+    assert events
+    # All events should be weather type
+    assert all(ev.event_type == "Weather" for ev in events)
+    count = _persist(events, bom_warnings_adapter.get_source_meta("http://example"))
     assert count == len(events)


### PR DESCRIPTION
## Summary
- implement BOM Queensland warnings adapter to fetch and normalize weather warnings
- add XML fixture and tests verifying weather events are inserted

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest ingest/tests/test_adapters.py::test_bom_warnings_adapter_normalizes_and_persists -q`

------
https://chatgpt.com/codex/tasks/task_e_68b239e4cc68832c84eadc8519ebc168