### PR TITLE
feat(ingest): ACSC RSS → events

### DIFF
--- a/ingest/acsc_adapter.py
+++ b/ingest/acsc_adapter.py
@@ -1,0 +1,5 @@
+from ingest.ingest.acsc_adapter import *  # noqa: F401,F403
+
+if __name__ == "__main__":  # pragma: no cover - thin wrapper
+    from ingest.ingest.acsc_adapter import main
+    main()

--- a/ingest/ingest/acsc_adapter.py
+++ b/ingest/ingest/acsc_adapter.py
@@ -1,0 +1,113 @@
+"""Adapter for ingesting ACSC advisories RSS feed.
+
+The adapter fetches the official Australian Cyber Security Centre RSS feed
+and stores each item as a normalised event in the database.  A small CLI is
+provided so it can be executed directly::
+
+    python -m ingest.acsc_adapter --since 7d
+
+The ``--since`` option filters items based on their publication date to
+avoid re-ingesting historical entries.
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from datetime import datetime
+from email.utils import parsedate_to_datetime
+from typing import List, Optional
+from urllib import request
+from xml.etree import ElementTree as ET
+
+from . import common
+
+FEED_URL = "https://www.cyber.gov.au/acsc/view-all-content/alerts/rss.xml"
+
+
+@dataclass
+class Event:
+    type: str
+    title: str
+    time: Optional[datetime]
+    source: Optional[str]
+    raw: str
+    entities: List[str] = field(default_factory=list)
+    location: Optional[str] = None
+
+
+def fetch(url: str = FEED_URL) -> str:
+    """Return the RSS feed as a text string."""
+    req = request.Request(url, headers={"User-Agent": "AOID-Ingest/1.0"})
+    with request.urlopen(req, timeout=20) as resp:  # nosec - controlled URL
+        return resp.read().decode("utf-8", errors="ignore")
+
+
+def parse(xml_text: str) -> List[Event]:
+    """Parse RSS XML into a list of :class:`Event` objects."""
+    root = ET.fromstring(xml_text)
+    events: List[Event] = []
+    for item in root.findall(".//item"):
+        title = (item.findtext("title") or "").strip()
+        link = item.findtext("link")
+        pub = item.findtext("pubDate")
+        try:
+            pub_dt = parsedate_to_datetime(pub) if pub else None
+        except Exception:
+            pub_dt = None
+        raw_xml = ET.tostring(item, encoding="unicode")
+        events.append(Event("cyber", title, pub_dt, link, raw_xml))
+    return events
+
+
+def insert_events(events: List[Event]) -> int:
+    """Insert events into the database, skipping duplicates."""
+    if not events:
+        return 0
+    inserted = 0
+    with common.get_conn() as conn:
+        with conn.cursor() as cur:
+            source_id = common.ensure_source(cur, "ACSC Alerts", FEED_URL, "cyber")
+            for ev in events:
+                if not ev.time:
+                    continue
+                if common.event_exists(cur, source_id, ev.title, ev.time):
+                    continue
+                res = common.insert_event(
+                    cur,
+                    source_id=source_id,
+                    title=ev.title,
+                    body=ev.source,  # store link as body for now
+                    event_type=ev.type,
+                    occurred_at=ev.time,
+                )
+                if res is not None:
+                    inserted += 1
+        conn.commit()
+    return inserted
+
+
+def run(since: str) -> int:
+    """Fetch the feed and persist recent events.
+
+    Parameters
+    ----------
+    since:
+        Duration string passed to :func:`common.parse_since` describing how
+        far back to ingest items.
+    """
+    cutoff = common.parse_since(since)
+    xml_text = fetch(FEED_URL)
+    events = [ev for ev in parse(xml_text) if ev.time and ev.time >= cutoff]
+    return insert_events(events)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Ingest ACSC advisories RSS feed")
+    parser.add_argument("--since", default="7d", help="Only ingest items newer than this (e.g. 7d, 12h)")
+    args = parser.parse_args(argv)
+    count = run(args.since)
+    print(f"Inserted {count} events")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/ingest/ingest/common/__init__.py
+++ b/ingest/ingest/common/__init__.py
@@ -1,0 +1,90 @@
+"""Common utilities for ingest adapters.
+
+This module exposes database helpers and small utilities that are shared
+between adapter command line interfaces.  It wraps the lower level helper
+functions from :mod:`ingest.common.db` with a couple of convenience
+functions used by the ACSC adapter tests.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import re
+from typing import Optional
+
+from . import db
+from . import schemas  # re-export for backwards compatibility
+
+__all__ = [
+    "db",
+    "schemas",
+    "get_conn",
+    "ensure_source",
+    "insert_event",
+    "event_exists",
+    "parse_since",
+]
+
+# Re-export core database helpers -------------------------------------------------
+get_conn = db.get_conn
+ensure_source = db.ensure_source
+
+
+def event_exists(cur, source_id: int, title: str, occurred_at: datetime) -> bool:
+    """Return ``True`` if an event already exists in the database."""
+    cur.execute(
+        "SELECT 1 FROM events WHERE source_id=%s AND title=%s AND occurred_at=%s",
+        (source_id, title, occurred_at.isoformat()),
+    )
+    return cur.fetchone() is not None
+
+
+def insert_event(
+    cur,
+    source_id: int,
+    title: str,
+    body: Optional[str],
+    event_type: str,
+    occurred_at: datetime,
+) -> Optional[int]:
+    """Insert an event if it does not already exist.
+
+    The underlying :func:`ingest.common.db.insert_event` helper does not
+    perform any de-duplication, so this wrapper first checks whether an
+    event with the same ``(source_id, title, occurred_at)`` triplet is
+    already present.  If so, ``None`` is returned and no insert occurs.
+    """
+
+    if event_exists(cur, source_id, title, occurred_at):
+        return None
+    return db.insert_event(
+        cur,
+        source_id=source_id,
+        title=title,
+        body=body,
+        event_type=event_type,
+        occurred_at=occurred_at.isoformat() if occurred_at else None,
+        lat=None,
+        lon=None,
+        jurisdiction=None,
+        confidence=None,
+        severity=None,
+    )
+
+
+_DURATION_RE = re.compile(r"^(\d+)([dh])$")
+
+
+def parse_since(value: str) -> datetime:
+    """Return a ``datetime`` representing ``value`` ago.
+
+    ``value`` should be of the form ``"7d"`` for seven days or ``"12h"``
+    for twelve hours.  A :class:`ValueError` is raised for unsupported
+    formats.
+    """
+
+    match = _DURATION_RE.match(value.strip())
+    if not match:
+        raise ValueError("duration should be like '7d' or '12h'")
+    amount, unit = match.groups()
+    delta = timedelta(days=int(amount)) if unit == "d" else timedelta(hours=int(amount))
+    return datetime.utcnow() - delta

--- a/ingest/tests/test_acsc_adapter_cli.py
+++ b/ingest/tests/test_acsc_adapter_cli.py
@@ -1,0 +1,80 @@
+import pathlib
+import sys
+
+BASE_PATH = pathlib.Path(__file__).resolve()
+sys.path.append(str(BASE_PATH.parents[2]))
+sys.path.append(str(BASE_PATH.parents[1]))
+
+from ingest import acsc_adapter, common  # type: ignore
+
+
+def load_fixture(name: str) -> str:
+    path = BASE_PATH.parents[1] / "ingest" / "fixtures" / name
+    return path.read_text(encoding="utf-8")
+
+
+class FakeCursor:
+    def __init__(self):
+        self.events = []
+        self._fetch = None
+
+    def execute(self, query, params=None):
+        q = query.strip()
+        if q.startswith("SELECT id FROM sources"):
+            self._fetch = (1,)
+        elif q.startswith("INSERT INTO sources"):
+            self._fetch = (1,)
+        elif q.startswith("SELECT 1 FROM events"):
+            src, title, occurred = params
+            for ev in self.events:
+                if ev[0] == src and ev[1] == title and ev[4] == occurred:
+                    self._fetch = (1,)
+                    break
+            else:
+                self._fetch = None
+        elif q.startswith("INSERT INTO events"):
+            # params: source_id, title, body, event_type, occurred_at, jurisdiction, confidence, severity
+            self.events.append(params)
+            self._fetch = (len(self.events),)
+        else:
+            self._fetch = None
+
+    def fetchone(self):
+        return self._fetch
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+class FakeConn:
+    def __init__(self):
+        self.cursor_obj = FakeCursor()
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+def test_acsc_rss_insert_and_dedupe(monkeypatch):
+    xml = load_fixture("acsc_alerts_sample.xml")
+    events = acsc_adapter.parse(xml)
+    assert events
+    conn = FakeConn()
+    monkeypatch.setattr(common, "get_conn", lambda: conn)
+    count1 = acsc_adapter.insert_events(events)
+    assert count1 >= 1
+    count2 = acsc_adapter.insert_events(events)
+    assert count2 == 0
+    # ensure at least one inserted event has type 'cyber'
+    assert any(ev[3] == "cyber" for ev in conn.cursor_obj.events)


### PR DESCRIPTION
## Summary
- add ACSC advisory adapter with CLI and date filtering
- provide ingest common helpers for dedupe and duration parsing
- test ACSC adapter RSS parsing and DB insertion logic

## Testing
- `pytest ingest/tests/test_acsc_adapter_cli.py -q`
- `pytest -q` *(fails: OperationalError connection refused for Postgres during alembic upgrade)*

------
https://chatgpt.com/codex/tasks/task_e_68b23f63dae8832c96ed562532170038