### PR TITLE
feat(ingest): BOM QLD warnings RSS → events

### DIFF
--- a/ingest/bom_warnings_adapter.py
+++ b/ingest/bom_warnings_adapter.py
@@ -1,0 +1,5 @@
+from ingest.ingest.bom_warnings_adapter import *  # noqa: F401,F403
+
+if __name__ == "__main__":  # pragma: no cover - thin wrapper
+    from ingest.ingest.bom_warnings_adapter import main
+    main()

--- a/ingest/ingest/adapters/bom_warnings_adapter.py
+++ b/ingest/ingest/adapters/bom_warnings_adapter.py
@@ -52,7 +52,7 @@ def normalize(raw: RawPayload) -> List[NormalizedEvent]:
             NormalizedEvent(
                 title=title,
                 body=desc,
-                event_type="Weather",
+                event_type="weather",
                 occurred_at=occurred_dt,
                 jurisdiction=area,
             )

--- a/ingest/ingest/bom_warnings_adapter.py
+++ b/ingest/ingest/bom_warnings_adapter.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from datetime import datetime
+from email.utils import parsedate_to_datetime
+from typing import List, Optional
+from urllib import request
+from xml.etree import ElementTree as ET
+
+from . import common
+
+FEED_URL = "http://www.bom.gov.au/fwo/IDZ00054.warnings_qld.xml"
+
+
+@dataclass
+class Event:
+    type: str
+    title: str
+    time: Optional[datetime]
+    source: Optional[str]
+    raw: str
+    entities: List[str] = field(default_factory=list)
+    location: Optional[str] = None
+
+
+def fetch(url: str = FEED_URL) -> str:
+    """Return the warnings feed as a text string."""
+    req = request.Request(url, headers={"User-Agent": "AOID-Ingest/1.0"})
+    with request.urlopen(req, timeout=20) as resp:  # nosec - controlled URL
+        return resp.read().decode("utf-8", errors="ignore")
+
+
+def parse(xml_text: str) -> List[Event]:
+    """Parse feed XML into a list of :class:`Event` objects."""
+    root = ET.fromstring(xml_text)
+    items = root.findall(".//item")
+    if not items:
+        items = root.findall(".//warning")
+    events: List[Event] = []
+    for item in items:
+        title = (item.findtext("title") or "").strip()
+        link = item.findtext("link")
+        pub = item.findtext("pubDate") or item.findtext("issued")
+        pub_dt: Optional[datetime] = None
+        if pub:
+            try:
+                pub_dt = parsedate_to_datetime(pub)
+            except Exception:
+                try:
+                    pub_dt = datetime.fromisoformat(pub.replace("Z", "+00:00"))
+                except Exception:
+                    pub_dt = None
+        raw_xml = ET.tostring(item, encoding="unicode")
+        events.append(Event("weather", title, pub_dt, link, raw_xml))
+    return events
+
+
+def insert_events(events: List[Event]) -> int:
+    """Insert events into the database, skipping duplicates."""
+    if not events:
+        return 0
+    inserted = 0
+    with common.get_conn() as conn:
+        with conn.cursor() as cur:
+            source_id = common.ensure_source(cur, "BOM QLD Warnings", FEED_URL, "weather")
+            for ev in events:
+                if not ev.time:
+                    continue
+                if common.event_exists(cur, source_id, ev.title, ev.time):
+                    continue
+                res = common.insert_event(
+                    cur,
+                    source_id=source_id,
+                    title=ev.title,
+                    body=ev.source,  # store link as body for now
+                    event_type=ev.type,
+                    occurred_at=ev.time,
+                )
+                if res is not None:
+                    inserted += 1
+        conn.commit()
+    return inserted
+
+
+def run(since: str) -> int:
+    """Fetch the feed and persist recent events."""
+    cutoff = common.parse_since(since)
+    xml_text = fetch(FEED_URL)
+    events = [ev for ev in parse(xml_text) if ev.time and ev.time >= cutoff]
+    return insert_events(events)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Ingest BOM QLD warnings RSS feed")
+    parser.add_argument("--since", default="48h", help="Only ingest items newer than this (e.g. 7d, 12h)")
+    args = parser.parse_args(argv)
+    count = run(args.since)
+    print(f"Inserted {count} events")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/ingest/tests/test_adapters.py
+++ b/ingest/tests/test_adapters.py
@@ -141,6 +141,6 @@ def test_bom_warnings_adapter_normalizes_and_persists():
     events = bom_warnings_adapter.normalize(raw)
     assert events
     # All events should be weather type
-    assert all(ev.event_type == "Weather" for ev in events)
+    assert all(ev.event_type == "weather" for ev in events)
     count = _persist(events, bom_warnings_adapter.get_source_meta("http://example"))
     assert count == len(events)

--- a/ingest/tests/test_bom_warnings_adapter_cli.py
+++ b/ingest/tests/test_bom_warnings_adapter_cli.py
@@ -1,0 +1,78 @@
+import pathlib
+import sys
+
+BASE_PATH = pathlib.Path(__file__).resolve()
+sys.path.append(str(BASE_PATH.parents[2]))
+sys.path.append(str(BASE_PATH.parents[1]))
+
+from ingest import bom_warnings_adapter, common  # type: ignore
+
+
+def load_fixture(name: str) -> str:
+    path = BASE_PATH.parents[1] / "ingest" / "fixtures" / name
+    return path.read_text(encoding="utf-8")
+
+
+class FakeCursor:
+    def __init__(self):
+        self.events = []
+        self._fetch = None
+
+    def execute(self, query, params=None):
+        q = query.strip()
+        if q.startswith("SELECT id FROM sources"):
+            self._fetch = (1,)
+        elif q.startswith("INSERT INTO sources"):
+            self._fetch = (1,)
+        elif q.startswith("SELECT 1 FROM events"):
+            src, title, occurred = params
+            for ev in self.events:
+                if ev[0] == src and ev[1] == title and ev[4] == occurred:
+                    self._fetch = (1,)
+                    break
+            else:
+                self._fetch = None
+        elif q.startswith("INSERT INTO events"):
+            self.events.append(params)
+            self._fetch = (len(self.events),)
+        else:
+            self._fetch = None
+
+    def fetchone(self):
+        return self._fetch
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+class FakeConn:
+    def __init__(self):
+        self.cursor_obj = FakeCursor()
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+def test_bom_warnings_insert_and_dedupe(monkeypatch):
+    xml = load_fixture("bom_warnings_sample.xml")
+    events = bom_warnings_adapter.parse(xml)
+    assert events
+    conn = FakeConn()
+    monkeypatch.setattr(common, "get_conn", lambda: conn)
+    count1 = bom_warnings_adapter.insert_events(events)
+    assert count1 >= 1
+    count2 = bom_warnings_adapter.insert_events(events)
+    assert count2 == 0
+    assert any(ev[3] == "weather" for ev in conn.cursor_obj.events)


### PR DESCRIPTION
## Summary
- add CLI adapter to fetch BOM Queensland warnings RSS and persist weather events
- ensure BOM warnings normalization uses lowercase `weather` type

## Testing
- `pytest ingest/tests/test_bom_warnings_adapter_cli.py -q`
- `pytest ingest/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b241e2829c832c897fd626776542d6