### PR TITLE
feat(frontend): Leaflet map with marker clustering

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,15 +9,20 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@types/leaflet": "^1.9.20",
         "axios": "^1.11.0",
+        "leaflet": "^1.9.4",
+        "leaflet.markercluster": "^1.5.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-leaflet": "^4.2.1",
         "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.55.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.0.1",
+        "@types/leaflet.markercluster": "^1.5.5",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
@@ -922,6 +927,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -1353,6 +1369,31 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.20",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.20.tgz",
+      "integrity": "sha512-rooalPMlk61LCaLOvBF2VIf9M47HgMQqi5xQ9QRi7c8PkdIe0WrIi5IxXUXQjAdL0c+vcQ01mYWbthzmp9GHWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/leaflet.markercluster": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@types/leaflet.markercluster/-/leaflet.markercluster-1.5.5.tgz",
+      "integrity": "sha512-TkWOhSHDM1ANxmLi+uK0PjsVcjIKBr8CLV2WoF16dIdeFmC0Cj5P5axkI3C1Xsi4+ht6EU8+BfEbbqEF9icPrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/leaflet": "*"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -2279,6 +2320,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2571,6 +2627,20 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,15 +11,20 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@types/leaflet": "^1.9.20",
     "axios": "^1.11.0",
+    "leaflet": "^1.9.4",
+    "leaflet.markercluster": "^1.5.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-leaflet": "^4.2.1",
     "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
+    "@types/leaflet.markercluster": "^1.5.5",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react'
+import { MapContainer, TileLayer } from 'react-leaflet'
+import L from 'leaflet'
+import 'leaflet.markercluster'
+import api from '../lib/api'
+import { Event } from '../types'
+
+const FALLBACK_CENTER: [number, number] = [-27.47, 153.03]
+const FALLBACK_ZOOM = 6
+
+export default function MapView() {
+  const mapRef = useRef<L.Map | null>(null)
+
+  useEffect(() => {
+    if (!mapRef.current) return
+    const cluster = L.markerClusterGroup()
+
+    api
+      .get<Event[]>('/events?since=48h&type=bushfire|weather|maritime')
+      .then((res) => {
+        const markers: L.Marker[] = []
+        res.data.forEach((ev) => {
+          if (typeof ev.lat === 'number' && typeof ev.lon === 'number') {
+            const marker = L.marker([ev.lat, ev.lon])
+            const title = ev.title ?? 'Untitled'
+            const time = (ev as any).time ?? ''
+            const type = (ev as any).type ?? ''
+            marker.bindPopup(`<strong>${title}</strong><br/>${time}<br/>${type}<br/>Open`)
+            markers.push(marker)
+          }
+        })
+
+        if (markers.length) {
+          cluster.addLayers(markers)
+          mapRef.current!.addLayer(cluster)
+          const bounds = L.latLngBounds(markers.map((m) => m.getLatLng()))
+          mapRef.current!.fitBounds(bounds)
+        } else {
+          mapRef.current!.setView(FALLBACK_CENTER, FALLBACK_ZOOM)
+        }
+      })
+      .catch((err) => console.error(err))
+  }, [])
+
+  return (
+    <MapContainer
+      center={FALLBACK_CENTER}
+      zoom={FALLBACK_ZOOM}
+      whenCreated={(map) => (mapRef.current = map)}
+      style={{ height: '100%', width: '100%' }}
+    >
+      <TileLayer
+        attribution="&copy; OpenStreetMap contributors"
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+    </MapContainer>
+  )
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
+import 'leaflet/dist/leaflet.css'
+import 'leaflet.markercluster/dist/MarkerCluster.css'
+import 'leaflet.markercluster/dist/MarkerCluster.Default.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -1,17 +1,5 @@
-import { useEffect } from 'react'
-import api from '../lib/api'
+import MapView from '../components/MapView'
 
 export default function MapPage() {
-  useEffect(() => {
-    api
-      .get('/events?since=48h&type=bushfire|weather|maritime')
-      .then((res) => {
-        console.log(res.data)
-      })
-      .catch((err) => {
-        console.error(err)
-      })
-  }, [])
-
-  return <div>Map Page</div>
+  return <MapView />
 }


### PR DESCRIPTION
## Summary
- add MapView component clustering events via Leaflet
- wire MapPage to render MapView and include Leaflet CSS
- install Leaflet, React Leaflet and markercluster dependencies

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b244db9c50832c8a5c1b25e485a9b8