### PR TITLE
feat(api): add /events endpoint with filters

### DIFF
--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -36,6 +36,7 @@ class Event(BaseModel):
     confidence: Optional[float] = None
     severity: Optional[float] = None
     geom: Optional[Any] = Field(default=None, description="Point/Polygon geometry placeholder")
+    raw: Optional[Any] = None
 
 
 class Entity(BaseModel):

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from services.api.app.main import app
+
+@pytest.fixture
+def client():
+    return TestClient(app)


### PR DESCRIPTION
## Summary
- add `/events` API returning filtered event slices with cursor-based pagination
- expand Event schema with optional `raw` payload
- cover event filtering, bounding boxes, pagination, and raw inclusion in tests

## Testing
- `pytest tests/api/test_events.py -q`
- `pytest tests/api/test_events.py services/api/tests -q` *(fails: subprocess.CalledProcessError: Command '['alembic', 'upgrade', '0003']' returned non-zero exit status 1.)*


------
https://chatgpt.com/codex/tasks/task_e_68b24897aba0832c871b819f2dbe4274