### PR TITLE
feat(api): /graph endpoint (two-hop) from events/entities

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -331,6 +331,134 @@ async def get_entity(entity_id: int):
     return {"id": entity_id, "type": "Org", "name": "Placeholder Org", "attrs": {}}
 
 
+@app.get("/graph")
+async def graph(
+    entity_id: int = Query(..., description="Root entity id"),
+    max: int = Query(200, ge=1, le=1000),
+):
+    """Return a two-hop graph neighbourhood for an entity.
+
+    The graph consists of entity and event nodes. Edges connect entities to
+    events as well as entities to other entities when they co-occur in the
+    same event. Edge weights represent the number of co-occurrences. Each
+    entity node includes provenance_counts aggregated from event_entities.
+    """
+
+    # First hop: events linked to the root entity
+    ev_rows = fetch_all(
+        """
+        SELECT ee.event_id
+        FROM event_entities ee
+        WHERE ee.entity_id=%s
+        ORDER BY ee.event_id
+        LIMIT %s
+        """,
+        (entity_id, max),
+    )
+    event_ids = [r["event_id"] for r in ev_rows]
+    if not event_ids:
+        return {"nodes": [], "edges": []}
+
+    # Fetch all entity-event edges within these events
+    ee_rows = fetch_all(
+        """
+        SELECT ee.event_id, ee.entity_id, ee.relation
+        FROM event_entities ee
+        WHERE ee.event_id = ANY(%s)
+        LIMIT %s
+        """,
+        (event_ids, max),
+    )
+
+    entity_ids = sorted({row["entity_id"] for row in ee_rows})
+
+    # Entity details
+    ent_rows = fetch_all(
+        "SELECT id, type, name FROM entities WHERE id = ANY(%s)",
+        (entity_ids,),
+    )
+    ent_lookup = {r["id"]: r for r in ent_rows}
+
+    # Event details
+    evt_rows = fetch_all(
+        "SELECT id, event_type, title FROM events WHERE id = ANY(%s)",
+        (event_ids,),
+    )
+    evt_lookup = {r["id"]: r for r in evt_rows}
+
+    # Provenance counts per entity
+    prov_rows = fetch_all(
+        """
+        SELECT entity_id, relation, COUNT(*) AS c
+        FROM event_entities
+        WHERE event_id = ANY(%s)
+        GROUP BY entity_id, relation
+        """,
+        (event_ids,),
+    )
+    prov_counts: dict[int, dict[str, int]] = {}
+    for r in prov_rows:
+        prov_counts.setdefault(r["entity_id"], {})[r["relation"]] = r["c"]
+
+    nodes = []
+    for eid in entity_ids:
+        ent = ent_lookup.get(eid, {})
+        nodes.append(
+            {
+                "id": eid,
+                "type": "entity",
+                "entity_type": ent.get("type"),
+                "name": ent.get("name"),
+                "provenance_counts": prov_counts.get(eid, {}),
+            }
+        )
+    for eid in event_ids:
+        ev = evt_lookup.get(eid, {})
+        nodes.append(
+            {
+                "id": eid,
+                "type": "event",
+                "event_type": ev.get("event_type"),
+                "title": ev.get("title"),
+            }
+        )
+
+    edges = []
+    for r in ee_rows:
+        edges.append(
+            {
+                "source": r["entity_id"],
+                "target": r["event_id"],
+                "type": "entity-event",
+                "relation": r.get("relation"),
+                "weight": 1,
+            }
+        )
+
+    pair_rows = fetch_all(
+        """
+        SELECT ee1.entity_id AS src, ee2.entity_id AS dst, COUNT(*) AS weight
+        FROM event_entities ee1
+        JOIN event_entities ee2 ON ee1.event_id = ee2.event_id
+        WHERE ee1.entity_id < ee2.entity_id AND ee1.event_id = ANY(%s)
+        GROUP BY src, dst
+        LIMIT %s
+        """,
+        (event_ids, max),
+    )
+    for r in pair_rows:
+        edges.append(
+            {
+                "source": r["src"],
+                "target": r["dst"],
+                "type": "entity-entity",
+                "weight": r["weight"],
+            }
+        )
+
+    return {"nodes": nodes, "edges": edges}
+
+
 @app.get("/graph/entity/{entity_id}")
 async def graph_entity(entity_id: int):
     ent = fetch_one("SELECT id, type, name FROM entities WHERE id=%s", (entity_id,))

--- a/services/api/tests/test_graph.py
+++ b/services/api/tests/test_graph.py
@@ -1,0 +1,110 @@
+import os
+import time
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(scope="module")
+def db_conn():
+    dsn = "postgresql://aoidb:aoidb@localhost/aoidb"
+    try:
+        conn = psycopg.connect(dsn)
+    except Exception:
+        pytest.skip("postgres not available")
+    with conn.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS event_entities")
+        cur.execute("DROP TABLE IF EXISTS events")
+        cur.execute("DROP TABLE IF EXISTS entities")
+        cur.execute("DROP TABLE IF EXISTS sources")
+        cur.execute("CREATE TABLE sources(id serial PRIMARY KEY, name text)")
+        cur.execute(
+            "CREATE TABLE events(id serial PRIMARY KEY, source_id int references sources(id), title text, event_type text)"
+        )
+        cur.execute("CREATE TABLE entities(id serial PRIMARY KEY, type text, name text)")
+        cur.execute(
+            "CREATE TABLE event_entities(event_id int references events(id), entity_id int references entities(id), relation text, score float)"
+        )
+    conn.commit()
+    os.environ["DATABASE_URL"] = dsn
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def graph_client(db_conn):
+    from app.main import app
+
+    return TestClient(app)
+
+
+def test_graph_two_hop(graph_client, db_conn):
+    with db_conn.cursor() as cur:
+        cur.execute("INSERT INTO sources(name) VALUES('src') RETURNING id")
+        src = cur.fetchone()[0]
+        cur.execute("INSERT INTO entities(type, name) VALUES('Org','Org1') RETURNING id")
+        org = cur.fetchone()[0]
+        cur.execute("INSERT INTO entities(type, name) VALUES('Person','Alice') RETURNING id")
+        alice = cur.fetchone()[0]
+        cur.execute("INSERT INTO entities(type, name) VALUES('Person','Bob') RETURNING id")
+        bob = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO events(source_id, title, event_type) VALUES(%s,'E1','t') RETURNING id",
+            (src,),
+        )
+        e1 = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO events(source_id, title, event_type) VALUES(%s,'E2','t') RETURNING id",
+            (src,),
+        )
+        e2 = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO events(source_id, title, event_type) VALUES(%s,'E3','t') RETURNING id",
+            (src,),
+        )
+        e3 = cur.fetchone()[0]
+        cur.executemany(
+            "INSERT INTO event_entities(event_id, entity_id, relation, score) VALUES (%s,%s,'mentioned',1.0)",
+            [
+                (e1, org),
+                (e1, alice),
+                (e2, org),
+                (e2, alice),
+                (e2, bob),
+                (e3, org),
+                (e3, bob),
+            ],
+        )
+    db_conn.commit()
+
+    r = graph_client.get(f"/graph?entity_id={org}&max=200")
+    assert r.status_code == 200
+    data = r.json()
+    nodes = data["nodes"]
+    edges = data["edges"]
+    assert len([n for n in nodes if n["type"] == "event"]) == 3
+    assert len([n for n in nodes if n["type"] == "entity"]) == 3
+    org_node = next(n for n in nodes if n["id"] == org)
+    assert org_node["provenance_counts"]["mentioned"] == 3
+    ee_edges = [e for e in edges if e["type"] == "entity-entity"]
+
+    def weight(a, b):
+        for e in ee_edges:
+            if (e["source"] == a and e["target"] == b) or (e["source"] == b and e["target"] == a):
+                return e["weight"]
+        return 0
+
+    assert weight(org, alice) == 2
+    assert weight(org, bob) == 2
+    assert len(edges) == 10
+
+    durations = []
+    for _ in range(20):
+        start = time.perf_counter()
+        graph_client.get(f"/graph?entity_id={org}&max=200")
+        durations.append(time.perf_counter() - start)
+    durations.sort()
+    idx = int(len(durations) * 0.95) - 1
+    p95 = durations[idx]
+    assert p95 < 0.2


### PR DESCRIPTION
## Summary
- add /graph endpoint building two-hop graph neighborhood via SQL joins
- report entity-event and entity-entity edges with weights and provenance counts
- add unit test for graph query structure and performance

## Testing
- `pytest services/api/tests/test_graph.py -q` *(fails: postgres not available)*
- `pytest services/api/tests/test_api.py::test_graph_entity_endpoint services/api/tests/test_api.py::test_graph_event_endpoint -q`

------
https://chatgpt.com/codex/tasks/task_e_68b24af42b20832cba54bdc12e5850c8