### PR TITLE
feat(api): notebooks CRUD and export (json/md/pdf)

### DIFF
--- a/services/api/alembic/versions/0004_notebooks.py
+++ b/services/api/alembic/versions/0004_notebooks.py
@@ -1,0 +1,35 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0004'
+down_revision = '0003'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'notebooks',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('title', sa.Text, nullable=False),
+        sa.Column('created_by', sa.Text, nullable=False),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+    )
+    op.create_table(
+        'notebook_items',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('notebook_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('notebooks.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('kind', sa.Text, nullable=False),
+        sa.CheckConstraint("kind IN ('event','entity')", name='ck_notebook_items_kind'),
+        sa.Column('ref_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('note', sa.Text, nullable=True),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+    )
+    op.create_index('ix_notebook_items_notebook_id', 'notebook_items', ['notebook_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_notebook_items_notebook_id', table_name='notebook_items')
+    op.drop_table('notebook_items')
+    op.drop_table('notebooks')

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -1,6 +1,8 @@
-from pydantic import BaseModel, Field
-from typing import Optional, List, Literal, Any
 from datetime import datetime
+from typing import Optional, List, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
 
 
 class Source(BaseModel):
@@ -35,8 +37,8 @@ class Event(BaseModel):
     jurisdiction: Optional[str] = None
     confidence: Optional[float] = None
     severity: Optional[float] = None
-    geom: Optional[Any] = Field(default=None, description="Point/Polygon geometry placeholder")
-    raw: Optional[Any] = None
+    geom: Optional[dict] = Field(default=None, description="Point/Polygon geometry placeholder")
+    raw: Optional[dict] = None
 
 
 class Entity(BaseModel):
@@ -47,22 +49,36 @@ class Entity(BaseModel):
     attrs: dict = {}
 
 
-class Notebook(BaseModel):
-    id: int
-    owner: str
-    title: str
-    items: list
+class NotebookItem(BaseModel):
+    id: UUID
+    kind: Literal['event', 'entity']
+    ref_id: UUID
+    note: Optional[str] = None
     created_at: Optional[datetime] = None
+    event: Optional[dict] = None
+    entity: Optional[dict] = None
+
+
+class Notebook(BaseModel):
+    id: UUID
+    title: str
+    created_by: str
+    created_at: Optional[datetime] = None
+    items: List[NotebookItem] = []
 
 
 class NotebookCreate(BaseModel):
     title: str
-    items: list
 
 
 class NotebookUpdate(BaseModel):
     title: Optional[str] = None
-    items: Optional[list] = None
+
+
+class NotebookItemCreate(BaseModel):
+    kind: Literal['event', 'entity']
+    ref_id: UUID
+    note: Optional[str] = None
 
 
 class SearchQuery(BaseModel):
@@ -70,4 +86,3 @@ class SearchQuery(BaseModel):
     bbox: Optional[str] = None
     time_range: Optional[str] = None
     limit: int = 50
-

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -7,13 +7,11 @@ typing-extensions>=4.12.2
 psycopg[binary]==3.2.1
 structlog==24.4.0
 PyJWT==2.9.0
-codex/extend-fastapi-for-notebook-crud-operations
 reportlab==4.2.0
 httpx==0.27.0
 
 python-jose==3.3.0
 python-multipart==0.0.20
-main
 SQLAlchemy==2.0.31
 alembic==1.13.1
 geoalchemy2==0.14.3

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -8,6 +8,9 @@ from fastapi.testclient import TestClient
 API_ROOT = Path(__file__).resolve().parents[1]
 if str(API_ROOT) not in sys.path:
     sys.path.insert(0, str(API_ROOT))
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 
 @pytest.fixture

--- a/services/api/tests/data/notebook_export.json
+++ b/services/api/tests/data/notebook_export.json
@@ -1,0 +1,22 @@
+{
+  "id": "11111111-1111-1111-1111-111111111111",
+  "title": "My NB",
+  "created_by": "anonymous",
+  "created_at": "2024-01-01T00:00:00",
+  "items": [
+    {
+      "id": "22222222-2222-2222-2222-222222222222",
+      "kind": "event",
+      "ref_id": "33333333-3333-3333-3333-333333333333",
+      "note": "Check this",
+      "created_at": "2024-01-01T00:00:00",
+      "event": {
+        "id": "33333333-3333-3333-3333-333333333333",
+        "title": "Sample Event",
+        "occurred_at": "2024-01-01T00:00:00",
+        "detected_at": "2024-01-01T01:00:00",
+        "source_url": "http://example.com/event"
+      }
+    }
+  ]
+}

--- a/services/api/tests/data/notebook_export.md
+++ b/services/api/tests/data/notebook_export.md
@@ -1,0 +1,3 @@
+# My NB
+
+- Sample Event (2024-01-01T00:00:00) http://example.com/event - Check this

--- a/services/api/tests/test_notebooks.py
+++ b/services/api/tests/test_notebooks.py
@@ -1,44 +1,145 @@
 import json
+from pathlib import Path
 from datetime import datetime
+from uuid import UUID
 
-def sample_nb():
-    return {
-        "id": 1,
-        "owner": "anonymous",
-        "title": "Test",
-        "items": [{"event": 2}],
-        "created_at": datetime.utcnow().isoformat()
+import pytest
+
+DATA_DIR = Path(__file__).parent / "data"
+FIXED_NOW = datetime(2024, 1, 1, 0, 0, 0)
+NOTEBOOK_ID = UUID("11111111-1111-1111-1111-111111111111")
+ITEM_ID = UUID("22222222-2222-2222-2222-222222222222")
+EVENT_ID = UUID("33333333-3333-3333-3333-333333333333")
+
+
+@pytest.fixture(autouse=True)
+def fixed_uuid(monkeypatch):
+    from app import main as m
+    ids = [UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), NOTEBOOK_ID, UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"), ITEM_ID, UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")]
+    def fake_uuid():
+        return ids.pop(0) if ids else UUID("99999999-9999-9999-9999-999999999999")
+    monkeypatch.setattr(m, "uuid4", fake_uuid)
+    return ids
+
+
+@pytest.fixture
+def inmem_db(monkeypatch):
+    from app import main as m
+    state = {
+        "notebooks": {},
+        "items": {},
+        "events": {
+            str(EVENT_ID): {
+                "id": str(EVENT_ID),
+                "title": "Sample Event",
+                "occurred_at": FIXED_NOW,
+                "detected_at": datetime(2024, 1, 1, 1, 0, 0),
+                "source_url": "http://example.com/event",
+            }
+        },
     }
 
-def test_notebook_crud(client, mock_fetch_one):
-    mock_fetch_one["result"] = sample_nb()
-    r = client.get("/notebooks/1")
-    assert r.status_code == 200
-    assert mock_fetch_one["calls"][0]["sql"].startswith("\n        SELECT")
+    def fetch_one(sql, params=()):
+        sql = " ".join(sql.strip().lower().split())
+        if sql.startswith("insert into notebooks"):
+            nb = {
+                "id": params[0],
+                "title": params[1],
+                "created_by": params[2],
+                "created_at": FIXED_NOW.isoformat(),
+            }
+            state["notebooks"][params[0]] = nb
+            return nb
+        if sql.startswith("insert into notebook_items"):
+            item = {
+                "id": params[0],
+                "notebook_id": params[1],
+                "kind": params[2],
+                "ref_id": params[3],
+                "note": params[4],
+                "created_at": FIXED_NOW.isoformat(),
+            }
+            state["items"].setdefault(params[1], []).append(item)
+            return item
+        if sql.startswith("select id, title, created_by, created_at from notebooks"):
+            nb = state["notebooks"].get(str(params[0]))
+            if nb and nb["created_by"] == params[1]:
+                return nb
+            return None
+        if sql.startswith("delete from notebooks"):
+            if params[0] in state["notebooks"]:
+                del state["notebooks"][params[0]]
+                return {"id": params[0]}
+            return None
+        if sql.startswith("delete from notebook_items"):
+            items = state["items"].get(params[1], [])
+            for i, it in enumerate(items):
+                if it["id"] == params[0]:
+                    del items[i]
+                    return {"id": params[0]}
+            return None
+        return None
 
-    mock_fetch_one["result"] = sample_nb() | {"id": 2, "title": "New"}
-    r = client.post("/notebooks", json={"title": "New", "items": []})
-    assert r.status_code == 200
-    assert mock_fetch_one["calls"][1]["sql"].strip().startswith("INSERT INTO notebooks")
+    def fetch_all(sql, params=()):
+        sql = " ".join(sql.strip().lower().split())
+        if sql.startswith("select ni.id"):
+            nb_id = params[0]
+            rows = []
+            for it in state["items"].get(nb_id, []):
+                row = {
+                    "id": it["id"],
+                    "kind": it["kind"],
+                    "ref_id": it["ref_id"],
+                    "note": it["note"],
+                    "created_at": FIXED_NOW.isoformat(),
+                    "event_title": None,
+                    "event_occurred_at": None,
+                    "event_detected_at": None,
+                    "source_url": None,
+                    "entity_name": None,
+                    "entity_type": None,
+                }
+                if it["kind"] == "event":
+                    ev = state["events"][it["ref_id"]]
+                    row.update({
+                        "event_title": ev["title"],
+                        "event_occurred_at": ev["occurred_at"].isoformat(),
+                        "event_detected_at": ev["detected_at"].isoformat(),
+                        "source_url": ev["source_url"],
+                    })
+                rows.append(row)
+            return rows
+        if sql.startswith("select id, title, created_by, created_at from notebooks where created_by="):
+            return list(state["notebooks"].values())
+        return []
 
-    mock_fetch_one["result"] = sample_nb() | {"title": "Updated"}
-    r = client.put("/notebooks/1", json={"title": "Updated", "items": [{"event": 2}]})
-    assert r.status_code == 200
-    assert mock_fetch_one["calls"][2]["sql"].strip().startswith("UPDATE notebooks")
+    monkeypatch.setattr(m, "fetch_one", fetch_one)
+    monkeypatch.setattr(m, "fetch_all", fetch_all)
+    return state
 
-def test_notebook_export(client, mock_fetch_one):
-    nb = sample_nb()
-    mock_fetch_one["result"] = nb
-    r = client.get("/notebooks/1/export?fmt=md")
-    assert r.status_code == 200
-    assert r.text.startswith("# ")
 
-    mock_fetch_one["result"] = nb
-    r = client.get("/notebooks/1/export?fmt=json")
+def test_notebook_flow(client, inmem_db):
+    r = client.post("/notebooks", json={"title": "My NB"})
     assert r.status_code == 200
-    assert r.json()["title"] == nb["title"]
+    nb_id = r.json()["id"]
 
-    mock_fetch_one["result"] = nb
-    r = client.get("/notebooks/1/export?fmt=pdf")
+    r = client.post(
+        f"/notebooks/{nb_id}/items",
+        json={"kind": "event", "ref_id": str(EVENT_ID), "note": "Check this"},
+    )
+    assert r.status_code == 200
+
+    r = client.get(f"/notebooks/{nb_id}/export?fmt=json")
+    assert r.status_code == 200
+    expected_json = json.loads((DATA_DIR / "notebook_export.json").read_text())
+    assert r.json() == expected_json
+
+    r = client.get(f"/notebooks/{nb_id}/export?fmt=md")
+    assert r.status_code == 200
+    expected_md = (DATA_DIR / "notebook_export.md").read_text()
+    assert r.text.strip() == expected_md.strip()
+
+    r = client.get(f"/notebooks/{nb_id}/export?fmt=pdf")
     assert r.status_code == 200
     assert r.headers["content-type"] == "application/pdf"
+    assert r.content.startswith(b"%PDF")


### PR DESCRIPTION
## Summary
- add Alembic migration and Pydantic models for notebooks and notebook_items
- implement CRUD endpoints and export (json/md/pdf) for notebooks
- test notebook creation, item addition and export against golden files

## Testing
- `pytest tests/test_notebooks.py -q`
- `pytest -q` *(fails: connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b24b058a58832c9cdebadf97185948