### PR TITLE
feat(frontend): timeline infinite scroll

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,12 @@
 import { Routes, Route, Navigate } from 'react-router-dom'
 import MapPage from './pages/MapPage'
+import TimelinePage from './pages/TimelinePage'
 
 export default function App() {
   return (
     <Routes>
       <Route path="/map" element={<MapPage />} />
+      <Route path="/timeline" element={<TimelinePage />} />
       <Route path="*" element={<Navigate to="/map" replace />} />
     </Routes>
   )

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Event } from '../types'
+import type { Event, TimelineEvent } from '../types'
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE || '/api',
@@ -8,4 +8,10 @@ export const api = axios.create({
 export function fetchEvents(types: string) {
   const typeParam = types ? `&type=${types}` : ''
   return api.get<Event[]>(`/events?since=48h${typeParam}`)
+}
+
+export async function fetchTimelineEvents(cursor?: string, limit = 50) {
+  const url = `/events?limit=${limit}${cursor ? `&cursor=${cursor}` : ''}`
+  const res = await api.get<TimelineEvent[]>(url)
+  return { events: res.data, nextCursor: res.headers['x-next-cursor'] as string | undefined }
 }

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react'
+import { fetchTimelineEvents } from '../lib/api'
+import type { TimelineEvent } from '../types'
+
+export default function TimelinePage() {
+  const [events, setEvents] = useState<TimelineEvent[]>([])
+  const [cursor, setCursor] = useState<string | undefined>()
+  const [loading, setLoading] = useState(false)
+
+  const loadMore = () => {
+    if (loading) return
+    setLoading(true)
+    fetchTimelineEvents(cursor)
+      .then(({ events: newEvents, nextCursor }) => {
+        setEvents((prev) => [...prev, ...newEvents])
+        setCursor(nextCursor)
+      })
+      .catch((err) => console.error(err))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => {
+    loadMore()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      {events.map((ev) => (
+        <div
+          key={ev.id}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            padding: '0.5rem 0',
+            borderBottom: '1px solid #ddd',
+          }}
+        >
+          <div style={{ width: '12rem', marginRight: '1rem' }}>
+            {new Date(ev.detected_at).toLocaleString()}
+          </div>
+          <span
+            style={{
+              marginRight: '1rem',
+              padding: '0.25rem 0.5rem',
+              borderRadius: '4px',
+              backgroundColor: '#e0e0e0',
+            }}
+          >
+            {ev.event_type}
+          </span>
+          <div style={{ flex: 1 }}>{ev.title}</div>
+          <button
+            type="button"
+            onClick={() => console.log('Add to Notebook', ev.id)}
+            style={{ marginLeft: '1rem' }}
+          >
+            Add to Notebook
+          </button>
+        </div>
+      ))}
+      {cursor && (
+        <div style={{ textAlign: 'center', marginTop: '1rem' }}>
+          <button type="button" onClick={loadMore} disabled={loading}>
+            {loading ? 'Loading...' : 'Load More'}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -13,3 +13,10 @@ export interface Event {
   entities: string[]
   source: string
 }
+
+export interface TimelineEvent {
+  id: string
+  title: string
+  event_type: EventType
+  detected_at: string
+}


### PR DESCRIPTION
## Summary
- add API helper for cursor-paginated events
- implement timeline page with load-more infinite scrolling
- expose /timeline route in app router

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b253a6883c832c8521bfdfe39d1bf9