### PR TITLE
feat(api): /healthz and /metrics endpoints

### DIFF
--- a/services/api/app/db.py
+++ b/services/api/app/db.py
@@ -1,2 +1,6 @@
-from ..db import get_conn, fetch_one, fetch_all
-from ..db.events import upsert_event
+try:  # pragma: no cover - compatibility for different import paths
+    from ..db import get_conn, fetch_one, fetch_all
+    from ..db.events import upsert_event
+except ImportError:  # when ``app`` is imported as top-level package in tests
+    from db import get_conn, fetch_one, fetch_all  # type: ignore
+    from db.events import upsert_event  # type: ignore

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -17,3 +17,5 @@ main
 SQLAlchemy==2.0.31
 alembic==1.13.1
 geoalchemy2==0.14.3
+redis==5.0.7
+prometheus-client==0.20.0

--- a/services/api/tests/test_health_metrics.py
+++ b/services/api/tests/test_health_metrics.py
@@ -1,0 +1,65 @@
+from contextlib import contextmanager
+
+import app.main as main
+from fastapi.testclient import TestClient
+
+
+def _ok_conn():
+    @contextmanager
+    def _conn():
+        class Cur:
+            def execute(self, sql):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                pass
+
+        class Conn:
+            def cursor(self):
+                return Cur()
+
+            def close(self):
+                pass
+
+        yield Conn()
+
+    return _conn()
+
+
+class _RedisOK:
+    def ping(self):
+        return True
+
+
+def test_healthz_ok(monkeypatch):
+    monkeypatch.setattr(main, "get_conn", _ok_conn)
+    monkeypatch.setattr(main.redis, "Redis", lambda *a, **k: _RedisOK())
+    client = TestClient(main.app)
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+
+def test_healthz_db_failure(monkeypatch):
+    @contextmanager
+    def _bad_conn():
+        raise Exception("db down")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(main, "get_conn", _bad_conn)
+    monkeypatch.setattr(main.redis, "Redis", lambda *a, **k: _RedisOK())
+    client = TestClient(main.app)
+    r = client.get("/healthz")
+    assert r.status_code == 500
+
+
+def test_metrics_endpoint(client):
+    r = client.get("/metrics")
+    assert r.status_code == 200
+    body = r.text
+    assert "request_total" in body
+    assert "error_total" in body
+


### PR DESCRIPTION
## Summary
- expose `/healthz` checking database and Redis connectivity
- add Prometheus `/metrics` endpoint with request and error counters
- test health and metrics behaviour and fix db import path

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'spacy')*
- `pytest services/api/tests/test_health_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68b253bb1810832cafd36ab4200c2f81