### PR TITLE
feat(frontend): add event drawer consuming /events/{id}

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,21 +1,17 @@
 import { Routes, Route, Navigate } from 'react-router-dom'
-import MapPage from './pages/MapPage'
-codex/add-/graph-route-and-graphpage-component
-import GraphPage from './pages/GraphPage'
 
+import MapPage from './pages/MapPage'
+import GraphPage from './pages/GraphPage'
 import TimelinePage from './pages/TimelinePage'
-main
 
 export default function App() {
   return (
     <Routes>
       <Route path="/map" element={<MapPage />} />
-codex/add-/graph-route-and-graphpage-component
       <Route path="/graph" element={<GraphPage />} />
-
       <Route path="/timeline" element={<TimelinePage />} />
-main
       <Route path="*" element={<Navigate to="/map" replace />} />
     </Routes>
   )
 }
+

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -48,9 +48,10 @@ const ICONS: Record<EventType, L.Icon> = {
 
 interface Props {
   types: string
+  onOpen: (id: string) => void
 }
 
-export default function MapView({ types }: Props) {
+export default function MapView({ types, onOpen }: Props) {
   const mapRef = useRef<L.Map | null>(null)
   const clusterRef = useRef<L.MarkerClusterGroup>(L.markerClusterGroup())
   const [mapReady, setMapReady] = useState(false)
@@ -68,11 +69,15 @@ export default function MapView({ types }: Props) {
             const popupDiv = document.createElement('div')
             const localTime = new Date(ev.time).toLocaleString()
             popupDiv.innerHTML = `<strong>${ev.title}</strong><br/>${localTime}<br/>${ev.type}<br/><a href="${ev.source}" target="_blank" rel="noopener noreferrer">Source</a><br/>`
+            const openBtn = document.createElement('button')
+            openBtn.textContent = 'Open'
+            openBtn.type = 'button'
+            openBtn.addEventListener('click', () => onOpen(ev.id))
+            popupDiv.appendChild(openBtn)
             const addBtn = document.createElement('button')
             addBtn.textContent = 'Add to Notebook'
             addBtn.type = 'button'
             addBtn.addEventListener('click', () => {
-              // Stub action - replace with real notebook integration
               console.log('Add to Notebook', ev.id)
             })
             popupDiv.appendChild(addBtn)
@@ -88,7 +93,7 @@ export default function MapView({ types }: Props) {
         }
       })
       .catch((err) => console.error(err))
-  }, [types])
+  }, [types, onOpen])
 
   useEffect(() => {
     if (!mapReady) return

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,9 +1,6 @@
 import axios from 'axios'
-codex/add-/graph-route-and-graphpage-component
-import type { Event, GraphData } from '../types'
 
-import type { Event, TimelineEvent } from '../types'
-main
+import type { Event, GraphData, TimelineEvent } from '../types'
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE || '/api',
@@ -14,14 +11,21 @@ export function fetchEvents(types: string) {
   return api.get<Event[]>(`/events?since=48h${typeParam}`)
 }
 
-codex/add-/graph-route-and-graphpage-component
+export function fetchEvent(id: string) {
+  return api.get<Event>(`/events/${id}`)
+}
+
 export function fetchGraph(entityId: string) {
   const param = entityId ? `?entity_id=${entityId}` : ''
   return api.get<GraphData>(`/graph${param}`)
+}
 
 export async function fetchTimelineEvents(cursor?: string, limit = 50) {
   const url = `/events?limit=${limit}${cursor ? `&cursor=${cursor}` : ''}`
   const res = await api.get<TimelineEvent[]>(url)
-  return { events: res.data, nextCursor: res.headers['x-next-cursor'] as string | undefined }
-main
+  return {
+    events: res.data,
+    nextCursor: res.headers['x-next-cursor'] as string | undefined,
+  }
 }
+

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import MapView from '../components/MapView'
+import EventDrawer from '../components/EventDrawer'
 import { MAP_EVENT_TYPES, MapEventType } from '../types'
 
 const TYPES = MAP_EVENT_TYPES.map((t) => ({
@@ -9,6 +10,7 @@ const TYPES = MAP_EVENT_TYPES.map((t) => ({
 
 export default function MapPage() {
   const [selected, setSelected] = useState<MapEventType[]>([...MAP_EVENT_TYPES])
+  const [openId, setOpenId] = useState<string | null>(null)
 
   const toggle = (type: string) => {
     setSelected((prev) =>
@@ -39,7 +41,8 @@ export default function MapPage() {
           </button>
         ))}
       </div>
-      <MapView types={typeQuery} />
+      <MapView types={typeQuery} onOpen={setOpenId} />
+      <EventDrawer eventId={openId} onClose={() => setOpenId(null)} />
     </>
   )
 }

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react'
 import { fetchTimelineEvents } from '../lib/api'
+import EventDrawer from '../components/EventDrawer'
 import type { TimelineEvent } from '../types'
 
 export default function TimelinePage() {
   const [events, setEvents] = useState<TimelineEvent[]>([])
   const [cursor, setCursor] = useState<string | undefined>()
   const [loading, setLoading] = useState(false)
+  const [openId, setOpenId] = useState<string | null>(null)
 
   const loadMore = () => {
     if (loading) return
@@ -52,8 +54,15 @@ export default function TimelinePage() {
           <div style={{ flex: 1 }}>{ev.title}</div>
           <button
             type="button"
-            onClick={() => console.log('Add to Notebook', ev.id)}
+            onClick={() => setOpenId(ev.id)}
             style={{ marginLeft: '1rem' }}
+          >
+            Open
+          </button>
+          <button
+            type="button"
+            onClick={() => console.log('Add to Notebook', ev.id)}
+            style={{ marginLeft: '0.5rem' }}
           >
             Add to Notebook
           </button>
@@ -66,6 +75,7 @@ export default function TimelinePage() {
           </button>
         </div>
       )}
+      <EventDrawer eventId={openId} onClose={() => setOpenId(null)} />
     </div>
   )
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -14,7 +14,6 @@ export interface Event {
   source: string
 }
 
-codex/add-/graph-route-and-graphpage-component
 export interface GraphNode {
   id: string
   label: string
@@ -30,11 +29,12 @@ export interface GraphLink {
 export interface GraphData {
   nodes: GraphNode[]
   links: GraphLink[]
+}
 
 export interface TimelineEvent {
   id: string
   title: string
   event_type: EventType
   detected_at: string
-main
 }
+


### PR DESCRIPTION
## Summary
- add sliding EventDrawer that fetches event details and supports notebook stubs
- hook MapPage and TimelinePage to open EventDrawer from map markers and timeline rows
- expand API utilities with fetchEvent

## Testing
- `npm test`
- `npm run build` (fails: Rollup failed to resolve import "d3-selection" from src/pages/GraphPage.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68b2567d1708832c87faea67ecc1bd7e