### PR TITLE
feat(notebooks): CRUD endpoints and basic UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,21 +1,17 @@
 import { Routes, Route, Navigate } from 'react-router-dom'
 import MapPage from './pages/MapPage'
-codex/add-/graph-route-and-graphpage-component
 import GraphPage from './pages/GraphPage'
-
 import TimelinePage from './pages/TimelinePage'
-main
+import NotebooksPage from './pages/NotebooksPage'
 
 export default function App() {
   return (
     <Routes>
-      <Route path="/map" element={<MapPage />} />
-codex/add-/graph-route-and-graphpage-component
-      <Route path="/graph" element={<GraphPage />} />
-
-      <Route path="/timeline" element={<TimelinePage />} />
-main
-      <Route path="*" element={<Navigate to="/map" replace />} />
+        <Route path="/map" element={<MapPage />} />
+        <Route path="/graph" element={<GraphPage />} />
+        <Route path="/timeline" element={<TimelinePage />} />
+        <Route path="/notebooks" element={<NotebooksPage />} />
+        <Route path="*" element={<Navigate to="/map" replace />} />
     </Routes>
   )
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,9 +1,5 @@
 import axios from 'axios'
-codex/add-/graph-route-and-graphpage-component
-import type { Event, GraphData } from '../types'
-
-import type { Event, TimelineEvent } from '../types'
-main
+import type { Event, GraphData, TimelineEvent, Notebook, NotebookItem } from '../types'
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE || '/api',
@@ -14,14 +10,50 @@ export function fetchEvents(types: string) {
   return api.get<Event[]>(`/events?since=48h${typeParam}`)
 }
 
-codex/add-/graph-route-and-graphpage-component
 export function fetchGraph(entityId: string) {
   const param = entityId ? `?entity_id=${entityId}` : ''
   return api.get<GraphData>(`/graph${param}`)
+}
 
 export async function fetchTimelineEvents(cursor?: string, limit = 50) {
   const url = `/events?limit=${limit}${cursor ? `&cursor=${cursor}` : ''}`
   const res = await api.get<TimelineEvent[]>(url)
   return { events: res.data, nextCursor: res.headers['x-next-cursor'] as string | undefined }
-main
+}
+
+export async function fetchNotebooks() {
+  const res = await api.get<Notebook[]>('/notebooks')
+  return res.data
+}
+
+export async function createNotebook(title: string) {
+  const res = await api.post<Notebook>('/notebooks', { title })
+  return res.data
+}
+
+export async function fetchNotebook(id: string) {
+  const res = await api.get<Notebook>(`/notebooks/${id}`)
+  return res.data
+}
+
+export async function addNotebookItem(
+  notebookId: string,
+  payload: { kind: 'event' | 'entity'; ref_id: string; note?: string }
+) {
+  const res = await api.post<NotebookItem>(`/notebooks/${notebookId}/items`, payload)
+  return res.data
+}
+
+export async function removeNotebookItem(notebookId: string, itemId: string) {
+  await api.delete(`/notebooks/${notebookId}/items/${itemId}`)
+}
+
+export async function fetchEvent(id: string) {
+  const res = await api.get<Event>(`/events/${id}`)
+  return res.data
+}
+
+export async function fetchEntity(id: string) {
+  const res = await api.get(`/entities/${id}`)
+  return res.data as any
 }

--- a/frontend/src/pages/NotebooksPage.tsx
+++ b/frontend/src/pages/NotebooksPage.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react'
+import { fetchNotebooks, createNotebook, fetchNotebook, removeNotebookItem, api } from '../lib/api'
+import type { Notebook, NotebookItem } from '../types'
+
+export default function NotebooksPage() {
+  const [notebooks, setNotebooks] = useState<Notebook[]>([])
+  const [newTitle, setNewTitle] = useState('')
+  const [selected, setSelected] = useState<Notebook | null>(null)
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  async function load() {
+    const data = await fetchNotebooks()
+    setNotebooks(data)
+  }
+
+  async function create() {
+    if (!newTitle.trim()) return
+    const nb = await createNotebook(newTitle.trim())
+    setNotebooks([nb, ...notebooks])
+    setNewTitle('')
+  }
+
+  async function open(id: string) {
+    let nb = await fetchNotebook(id)
+    const items = nb.items || []
+    const withTitles: NotebookItem[] = await Promise.all(
+      items.map(async (it) => {
+        if (it.kind === 'event') {
+          const res = await api.get(`/events/${it.ref_id}`)
+          return { ...it, title: res.data.title }
+        }
+        if (it.kind === 'entity') {
+          const res = await api.get(`/entities/${it.ref_id}`)
+          return { ...it, title: res.data.name }
+        }
+        return it
+      })
+    )
+    nb.items = withTitles
+    setSelected(nb)
+  }
+
+  async function remove(itemId: string) {
+    if (!selected) return
+    await removeNotebookItem(selected.id, itemId)
+    setSelected({
+      ...selected,
+      items: (selected.items || []).filter((i) => i.id !== itemId),
+    })
+  }
+
+  return (
+    <div className="p-4">
+      <h1>Notebooks</h1>
+      <div>
+        <input
+          value={newTitle}
+          onChange={(e) => setNewTitle(e.target.value)}
+          placeholder="New notebook title"
+        />
+        <button onClick={create}>Create</button>
+      </div>
+      <ul>
+        {notebooks.map((nb) => (
+          <li key={nb.id}>
+            <button onClick={() => open(nb.id)}>{nb.title}</button>
+          </li>
+        ))}
+      </ul>
+      {selected && (
+        <div className="mt-4">
+          <h2>{selected.title}</h2>
+          <ul>
+            {(selected.items || []).map((item) => (
+              <li key={item.id}>
+                <span style={{ marginRight: '0.5rem' }}>{item.title || item.ref_id}</span>
+                <span
+                  style={{
+                    border: '1px solid #ccc',
+                    padding: '0 4px',
+                    marginRight: '0.5rem',
+                  }}
+                >
+                  {item.kind}
+                </span>
+                <button onClick={() => remove(item.id)}>remove</button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -14,7 +14,6 @@ export interface Event {
   source: string
 }
 
-codex/add-/graph-route-and-graphpage-component
 export interface GraphNode {
   id: string
   label: string
@@ -30,11 +29,29 @@ export interface GraphLink {
 export interface GraphData {
   nodes: GraphNode[]
   links: GraphLink[]
+}
 
 export interface TimelineEvent {
   id: string
   title: string
   event_type: EventType
   detected_at: string
-main
+}
+
+export interface NotebookItem {
+  id: string
+  notebook_id: string
+  kind: 'event' | 'entity'
+  ref_id: string
+  note?: string | null
+  created_at?: string
+  title?: string
+}
+
+export interface Notebook {
+  id: string
+  created_by: string
+  title: string
+  created_at?: string
+  items?: NotebookItem[]
 }

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -714,15 +714,12 @@ async def add_notebook_item(
     return row
 
 
-@app.delete("/notebooks/{notebook_id}/items")
+@app.delete("/notebooks/{notebook_id}/items/{item_id}")
 async def delete_notebook_item(
     notebook_id: UUID,
-    payload: dict,
+    item_id: UUID,
     user: dict = Depends(get_current_user),
 ):
-    item_id = payload.get("item_id")
-    if not item_id:
-        raise HTTPException(status_code=400, detail="Missing item_id")
     row = fetch_one(
         """
         DELETE FROM notebook_items WHERE id=%s AND notebook_id=%s AND EXISTS (
@@ -733,7 +730,7 @@ async def delete_notebook_item(
     )
     if not row:
         raise HTTPException(status_code=404, detail="Item not found")
-    return {"status": "deleted", "id": item_id}
+    return {"status": "deleted", "id": str(item_id)}
 
 
 @app.get("/notebooks/{notebook_id}/export")

--- a/services/api/db/migrations/0002_create_notebooks_tables.sql
+++ b/services/api/db/migrations/0002_create_notebooks_tables.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS notebooks (
+    id UUID PRIMARY KEY,
+    title TEXT NOT NULL,
+    created_by TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS notebook_items (
+    id UUID PRIMARY KEY,
+    notebook_id UUID REFERENCES notebooks(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL CHECK (kind IN ('event','entity')),
+    ref_id UUID NOT NULL,
+    note TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/services/api/tests/test_db.py
+++ b/services/api/tests/test_db.py
@@ -15,11 +15,8 @@ def db_conn():
     try:
         conn = psycopg.connect(dsn)
     except psycopg.OperationalError:
- codex/add-event-and-entity-detail-endpoints
-        pytest.skip("database not available")
-
         pytest.skip("PostgreSQL server not available")
- main
+
     migrations = ROOT / "db" / "migrations"
     with conn.cursor() as cur:
         for path in sorted(migrations.glob("*.sql")):

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -8,6 +8,12 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from prometheus_client import REGISTRY
+
+# Clear any existing collectors to avoid duplicate metric registration during tests
+for collector in list(REGISTRY._collector_to_names.keys()):
+    REGISTRY.unregister(collector)
+
 from services.api.app.main import app
 
 @pytest.fixture

--- a/tests/api/test_notebooks_crud.py
+++ b/tests/api/test_notebooks_crud.py
@@ -1,0 +1,94 @@
+from uuid import UUID, uuid4
+from datetime import datetime, timezone
+
+import services.api.app.main as m
+
+
+def _iso(dt: datetime) -> str:
+    return dt.replace(tzinfo=timezone.utc).isoformat()
+
+
+def test_notebook_crud_endpoints(client, monkeypatch):
+    nb_id = UUID("11111111-1111-4111-8111-111111111111")
+    item_id = UUID("22222222-2222-4222-8222-222222222222")
+    created_at = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    calls = {"fetch_one": [], "fetch_all": []}
+
+    def fake_fetch_one(sql, params=()):
+        calls["fetch_one"].append({"sql": sql, "params": params})
+        s = " ".join(sql.split()).lower()
+        if s.startswith("insert into notebooks"):
+            return {
+                "id": nb_id,
+                "created_by": "anonymous",
+                "title": params[2],
+                "created_at": created_at,
+            }
+        if s.startswith("delete from notebooks"):
+            return {"id": nb_id}
+        if s.startswith("insert into notebook_items"):
+            return {
+                "id": item_id,
+                "notebook_id": params[1],
+                "kind": params[2],
+                "ref_id": params[3],
+                "note": params[4],
+                "created_at": created_at,
+            }
+        if s.startswith("delete from notebook_items"):
+            return {"id": params[0]}
+        return None
+
+    def fake_fetch_all(sql, params=()):
+        calls["fetch_all"].append({"sql": sql, "params": params})
+        s = " ".join(sql.split()).lower()
+        if s.startswith("select id, created_by, title, created_at from notebooks"):
+            return [
+                {
+                    "id": nb_id,
+                    "created_by": "anonymous",
+                    "title": "My Notebook",
+                    "created_at": created_at,
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(m, "fetch_one", fake_fetch_one)
+    monkeypatch.setattr(m, "fetch_all", fake_fetch_all)
+
+    # Create notebook
+    r = client.post("/notebooks", json={"title": "My Notebook"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["id"] == str(nb_id)
+    assert data["title"] == "My Notebook"
+
+    # List notebooks
+    r = client.get("/notebooks")
+    assert r.status_code == 200
+    lst = r.json()
+    assert isinstance(lst, list) and lst[0]["id"] == str(nb_id)
+
+    # Add item
+    r = client.post(
+        f"/notebooks/{nb_id}/items",
+        json={"kind": "event", "ref_id": str(uuid4()), "note": "first"},
+    )
+    assert r.status_code == 200
+    item = r.json()
+    assert item["id"] == str(item_id)
+
+    # Delete item
+    r = client.delete(f"/notebooks/{nb_id}/items/{item_id}")
+    assert r.status_code == 200
+    assert r.json()["id"] == str(item_id)
+
+    # Delete notebook
+    r = client.delete(f"/notebooks/{nb_id}")
+    assert r.status_code == 200
+    assert r.json()["id"] == str(nb_id)
+
+    # Ensure expected SQL executed
+    assert any("insert into notebooks" in call["sql"].lower() for call in calls["fetch_one"])
+    assert any("delete from notebooks" in call["sql"].lower() for call in calls["fetch_one"])


### PR DESCRIPTION
## Summary
- add database tables for notebooks and notebook_items
- expose CRUD endpoints for notebooks and their items
- add React notebooks page with list and item removal

## Testing
- `npm test`
- `pytest tests/api/test_notebooks_crud.py`
- `pytest` *(fails: Duplicated timeseries & 404 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b25685519c832c8ab19f5cbb843fe7