### PR TITLE
feat(graph): add /graph API and D3 frontend integration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,20 +1,14 @@
 import { Routes, Route, Navigate } from 'react-router-dom'
 import MapPage from './pages/MapPage'
-codex/add-/graph-route-and-graphpage-component
 import GraphPage from './pages/GraphPage'
-
 import TimelinePage from './pages/TimelinePage'
-main
 
 export default function App() {
   return (
     <Routes>
       <Route path="/map" element={<MapPage />} />
-codex/add-/graph-route-and-graphpage-component
       <Route path="/graph" element={<GraphPage />} />
-
       <Route path="/timeline" element={<TimelinePage />} />
-main
       <Route path="*" element={<Navigate to="/map" replace />} />
     </Routes>
   )

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,9 +1,5 @@
 import axios from 'axios'
-codex/add-/graph-route-and-graphpage-component
-import type { Event, GraphData } from '../types'
-
-import type { Event, TimelineEvent } from '../types'
-main
+import type { Event, GraphData, TimelineEvent } from '../types'
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE || '/api',
@@ -14,14 +10,16 @@ export function fetchEvents(types: string) {
   return api.get<Event[]>(`/events?since=48h${typeParam}`)
 }
 
-codex/add-/graph-route-and-graphpage-component
 export function fetchGraph(entityId: string) {
   const param = entityId ? `?entity_id=${entityId}` : ''
   return api.get<GraphData>(`/graph${param}`)
+}
 
 export async function fetchTimelineEvents(cursor?: string, limit = 50) {
   const url = `/events?limit=${limit}${cursor ? `&cursor=${cursor}` : ''}`
   const res = await api.get<TimelineEvent[]>(url)
-  return { events: res.data, nextCursor: res.headers['x-next-cursor'] as string | undefined }
-main
+  return {
+    events: res.data,
+    nextCursor: res.headers['x-next-cursor'] as string | undefined,
+  }
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -14,14 +14,14 @@ export interface Event {
   source: string
 }
 
-codex/add-/graph-route-and-graphpage-component
 export interface GraphNode {
   id: string
   label: string
   kind: 'entity' | 'event'
+  type?: string
 }
 
-export interface GraphLink {
+export interface GraphEdge {
   source: string
   target: string
   weight: number
@@ -29,12 +29,12 @@ export interface GraphLink {
 
 export interface GraphData {
   nodes: GraphNode[]
-  links: GraphLink[]
+  edges: GraphEdge[]
+}
 
 export interface TimelineEvent {
   id: string
   title: string
   event_type: EventType
   detected_at: string
-main
 }

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -424,21 +424,19 @@ async def graph(
     entity_id: int = Query(..., description="Root entity id"),
     max: int = Query(200, ge=1, le=1000),
 ):
-    """Return a two-hop graph neighbourhood for an entity.
+    """Return a simple two-hop graph neighbourhood.
 
-    The graph consists of entity and event nodes. Edges connect entities to
-    events as well as entities to other entities when they co-occur in the
-    same event. Edge weights represent the number of co-occurrences. Each
-    entity node includes provenance_counts aggregated from event_entities.
+    Nodes represent events or entities. Edges connect entities to events and
+    co-occurring entities. Results are capped by ``max``.
     """
 
-    # First hop: events linked to the root entity
+    # First, find events linked to the root entity
     ev_rows = fetch_all(
         """
-        SELECT ee.event_id
-        FROM event_entities ee
-        WHERE ee.entity_id=%s
-        ORDER BY ee.event_id
+        SELECT event_id
+        FROM event_entities
+        WHERE entity_id=%s
+        ORDER BY event_id
         LIMIT %s
         """,
         (entity_id, max),
@@ -447,17 +445,16 @@ async def graph(
     if not event_ids:
         return {"nodes": [], "edges": []}
 
-    # Fetch all entity-event edges within these events
+    # All entity-event edges within these events
     ee_rows = fetch_all(
         """
-        SELECT ee.event_id, ee.entity_id, ee.relation
-        FROM event_entities ee
-        WHERE ee.event_id = ANY(%s)
+        SELECT event_id, entity_id
+        FROM event_entities
+        WHERE event_id = ANY(%s)
         LIMIT %s
         """,
         (event_ids, max),
     )
-
     entity_ids = sorted({row["entity_id"] for row in ee_rows})
 
     # Entity details
@@ -474,30 +471,15 @@ async def graph(
     )
     evt_lookup = {r["id"]: r for r in evt_rows}
 
-    # Provenance counts per entity
-    prov_rows = fetch_all(
-        """
-        SELECT entity_id, relation, COUNT(*) AS c
-        FROM event_entities
-        WHERE event_id = ANY(%s)
-        GROUP BY entity_id, relation
-        """,
-        (event_ids,),
-    )
-    prov_counts: dict[int, dict[str, int]] = {}
-    for r in prov_rows:
-        prov_counts.setdefault(r["entity_id"], {})[r["relation"]] = r["c"]
-
     nodes = []
     for eid in entity_ids:
         ent = ent_lookup.get(eid, {})
         nodes.append(
             {
                 "id": eid,
-                "type": "entity",
-                "entity_type": ent.get("type"),
-                "name": ent.get("name"),
-                "provenance_counts": prov_counts.get(eid, {}),
+                "label": ent.get("name"),
+                "kind": "entity",
+                "type": ent.get("type"),
             }
         )
     for eid in event_ids:
@@ -505,24 +487,17 @@ async def graph(
         nodes.append(
             {
                 "id": eid,
-                "type": "event",
-                "event_type": ev.get("event_type"),
-                "title": ev.get("title"),
+                "label": ev.get("title"),
+                "kind": "event",
+                "type": ev.get("event_type"),
             }
         )
 
     edges = []
     for r in ee_rows:
-        edges.append(
-            {
-                "source": r["entity_id"],
-                "target": r["event_id"],
-                "type": "entity-event",
-                "relation": r.get("relation"),
-                "weight": 1,
-            }
-        )
+        edges.append({"source": r["entity_id"], "target": r["event_id"], "weight": 1})
 
+    # Entity co-occurrence edges
     pair_rows = fetch_all(
         """
         SELECT ee1.entity_id AS src, ee2.entity_id AS dst, COUNT(*) AS weight
@@ -535,14 +510,7 @@ async def graph(
         (event_ids, max),
     )
     for r in pair_rows:
-        edges.append(
-            {
-                "source": r["src"],
-                "target": r["dst"],
-                "type": "entity-entity",
-                "weight": r["weight"],
-            }
-        )
+        edges.append({"source": r["src"], "target": r["dst"], "weight": r["weight"]})
 
     return {"nodes": nodes, "edges": edges}
 


### PR DESCRIPTION
## Summary
- build `/graph` endpoint to return two-hop entity/event neighborhood
- add D3-powered graph page with hover and click interactions
- wire up frontend API and types for graph data

## Testing
- `pytest services/api/tests/test_graph.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_68b2568f76dc832c93f699784073de97