### PR TITLE
feat(frontend): add type/date filters to timeline

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,9 +1,6 @@
 import axios from 'axios'
-codex/add-/graph-route-and-graphpage-component
-import type { Event, GraphData } from '../types'
 
-import type { Event, TimelineEvent } from '../types'
-main
+import type { Event, GraphData, TimelineEvent } from '../types'
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE || '/api',
@@ -14,14 +11,33 @@ export function fetchEvents(types: string) {
   return api.get<Event[]>(`/events?since=48h${typeParam}`)
 }
 
-codex/add-/graph-route-and-graphpage-component
 export function fetchGraph(entityId: string) {
   const param = entityId ? `?entity_id=${entityId}` : ''
   return api.get<GraphData>(`/graph${param}`)
-
-export async function fetchTimelineEvents(cursor?: string, limit = 50) {
-  const url = `/events?limit=${limit}${cursor ? `&cursor=${cursor}` : ''}`
-  const res = await api.get<TimelineEvent[]>(url)
-  return { events: res.data, nextCursor: res.headers['x-next-cursor'] as string | undefined }
-main
 }
+
+interface TimelineQuery {
+  cursor?: string
+  limit?: number
+  types?: string
+  since?: string
+}
+
+export async function fetchTimelineEvents({
+  cursor,
+  limit = 50,
+  types,
+  since,
+}: TimelineQuery) {
+  const params = new URLSearchParams()
+  params.set('limit', String(limit))
+  if (cursor) params.set('cursor', cursor)
+  if (since) params.set('since', since)
+  if (types) params.set('type', types)
+  const res = await api.get<TimelineEvent[]>(`/events?${params.toString()}`)
+  return {
+    events: res.data,
+    nextCursor: res.headers['x-next-cursor'] as string | undefined,
+  }
+}
+

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -1,18 +1,40 @@
 import { useEffect, useState } from 'react'
 import { fetchTimelineEvents } from '../lib/api'
-import type { TimelineEvent } from '../types'
+import type { EventType, TimelineEvent } from '../types'
+
+const EVENT_TYPES: EventType[] = ['bushfire', 'weather', 'maritime', 'cyber', 'news']
+const TYPE_CHIPS = [
+  { key: 'all', label: 'All' },
+  ...EVENT_TYPES.map((t) => ({
+    key: t,
+    label: t.charAt(0).toUpperCase() + t.slice(1),
+  })),
+]
+
+const RANGES = [
+  { value: '24h', label: 'Last 24h' },
+  { value: '48h', label: 'Last 48h' },
+  { value: '7d', label: 'Last 7d' },
+  { value: '30d', label: 'Last 30d' },
+]
 
 export default function TimelinePage() {
   const [events, setEvents] = useState<TimelineEvent[]>([])
   const [cursor, setCursor] = useState<string | undefined>()
   const [loading, setLoading] = useState(false)
+  const [selectedTypes, setSelectedTypes] = useState<EventType[]>([...EVENT_TYPES])
+  const [since, setSince] = useState('48h')
 
-  const loadMore = () => {
+  const typeQuery =
+    selectedTypes.length === EVENT_TYPES.length ? undefined : selectedTypes.join('|')
+
+  const loadMore = (reset = false) => {
     if (loading) return
     setLoading(true)
-    fetchTimelineEvents(cursor)
+    const currentCursor = reset ? undefined : cursor
+    fetchTimelineEvents({ cursor: currentCursor, types: typeQuery, since })
       .then(({ events: newEvents, nextCursor }) => {
-        setEvents((prev) => [...prev, ...newEvents])
+        setEvents((prev) => (reset ? newEvents : [...prev, ...newEvents]))
         setCursor(nextCursor)
       })
       .catch((err) => console.error(err))
@@ -20,48 +42,100 @@ export default function TimelinePage() {
   }
 
   useEffect(() => {
-    loadMore()
+    loadMore(true)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [typeQuery, since])
+
+  const toggleType = (key: string) => {
+    if (key === 'all') {
+      setSelectedTypes([...EVENT_TYPES])
+    } else {
+      setSelectedTypes((prev) =>
+        prev.includes(key as EventType)
+          ? prev.filter((t) => t !== key)
+          : [...prev, key as EventType]
+      )
+    }
+  }
 
   return (
     <div style={{ padding: '1rem' }}>
-      {events.map((ev) => (
-        <div
-          key={ev.id}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            padding: '0.5rem 0',
-            borderBottom: '1px solid #ddd',
-          }}
+      <div style={{ marginBottom: '0.5rem' }}>
+        {TYPE_CHIPS.map(({ key, label }) => {
+          const active =
+            key === 'all'
+              ? selectedTypes.length === EVENT_TYPES.length
+              : selectedTypes.includes(key as EventType)
+          return (
+            <button
+              key={key}
+              onClick={() => toggleType(key)}
+              style={{
+                marginRight: '0.5rem',
+                padding: '0.25rem 0.5rem',
+                borderRadius: '16px',
+                border: '1px solid #ccc',
+                backgroundColor: active ? '#1976d2' : '#e0e0e0',
+                color: active ? '#fff' : '#000',
+                cursor: 'pointer',
+              }}
+            >
+              {label}
+            </button>
+          )
+        })}
+        <select
+          value={since}
+          onChange={(e) => setSince(e.target.value)}
+          style={{ marginLeft: '1rem' }}
         >
-          <div style={{ width: '12rem', marginRight: '1rem' }}>
-            {new Date(ev.detected_at).toLocaleString()}
-          </div>
-          <span
+          {RANGES.map((r) => (
+            <option key={r.value} value={r.value}>
+              {r.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      {loading && events.length === 0 ? (
+        <div>Loading...</div>
+      ) : (
+        events.map((ev) => (
+          <div
+            key={ev.id}
             style={{
-              marginRight: '1rem',
-              padding: '0.25rem 0.5rem',
-              borderRadius: '4px',
-              backgroundColor: '#e0e0e0',
+              display: 'flex',
+              alignItems: 'center',
+              padding: '0.5rem 0',
+              borderBottom: '1px solid #ddd',
             }}
           >
-            {ev.event_type}
-          </span>
-          <div style={{ flex: 1 }}>{ev.title}</div>
-          <button
-            type="button"
-            onClick={() => console.log('Add to Notebook', ev.id)}
-            style={{ marginLeft: '1rem' }}
-          >
-            Add to Notebook
-          </button>
-        </div>
-      ))}
+            <div style={{ width: '12rem', marginRight: '1rem' }}>
+              {new Date(ev.detected_at).toLocaleString()}
+            </div>
+            <span
+              style={{
+                marginRight: '1rem',
+                padding: '0.25rem 0.5rem',
+                borderRadius: '4px',
+                backgroundColor: '#e0e0e0',
+              }}
+            >
+              {ev.event_type}
+            </span>
+            <div style={{ flex: 1 }}>{ev.title}</div>
+            <button
+              type="button"
+              onClick={() => console.log('Add to Notebook', ev.id)}
+              style={{ marginLeft: '1rem' }}
+            >
+              Add to Notebook
+            </button>
+          </div>
+        ))
+      )}
       {cursor && (
         <div style={{ textAlign: 'center', marginTop: '1rem' }}>
-          <button type="button" onClick={loadMore} disabled={loading}>
+          <button type="button" onClick={() => loadMore()} disabled={loading}>
             {loading ? 'Loading...' : 'Load More'}
           </button>
         </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -14,7 +14,6 @@ export interface Event {
   source: string
 }
 
-codex/add-/graph-route-and-graphpage-component
 export interface GraphNode {
   id: string
   label: string
@@ -30,11 +29,12 @@ export interface GraphLink {
 export interface GraphData {
   nodes: GraphNode[]
   links: GraphLink[]
+}
 
 export interface TimelineEvent {
   id: string
   title: string
   event_type: EventType
   detected_at: string
-main
 }
+


### PR DESCRIPTION
## Summary
- add filter chips and date range selector to timeline
- extend api helper to include type and since query params
- refresh timeline on filter changes with loading state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b256b6b0c4832c99cbeb101291f4b0