### PR TITLE
chore: tidy api requirements

### DIFF
--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -7,13 +7,10 @@ typing-extensions>=4.12.2
 psycopg[binary]==3.2.1
 structlog==24.4.0
 PyJWT==2.9.0
-codex/extend-fastapi-for-notebook-crud-operations
 reportlab==4.2.0
 httpx==0.27.0
-
 python-jose==3.3.0
 python-multipart==0.0.20
-main
 SQLAlchemy==2.0.31
 alembic==1.13.1
 geoalchemy2==0.14.3


### PR DESCRIPTION
## Summary
- remove non-package entries from API requirements
- ensure each requirement refers to a valid PyPI package

## Testing
- `pip install --dry-run --no-deps -r services/api/requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b25b65b038832cadc680a9dbb47b5f