### PR TITLE
Clean frontend after merge

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,29 +3,16 @@ import { Routes, Route, Navigate } from 'react-router-dom'
 import MapPage from './pages/MapPage'
 import GraphPage from './pages/GraphPage'
 import TimelinePage from './pages/TimelinePage'
-codex/add-get-/graph-api-and-frontend-integration
-
-codex/add-crud-functionality-for-notebooks
 import NotebooksPage from './pages/NotebooksPage'
-
-main
-main
 
 export default function App() {
   return (
     <Routes>
-codex/add-crud-functionality-for-notebooks
-        <Route path="/map" element={<MapPage />} />
-        <Route path="/graph" element={<GraphPage />} />
-        <Route path="/timeline" element={<TimelinePage />} />
-        <Route path="/notebooks" element={<NotebooksPage />} />
-        <Route path="*" element={<Navigate to="/map" replace />} />
-
       <Route path="/map" element={<MapPage />} />
       <Route path="/graph" element={<GraphPage />} />
       <Route path="/timeline" element={<TimelinePage />} />
+      <Route path="/notebooks" element={<NotebooksPage />} />
       <Route path="*" element={<Navigate to="/map" replace />} />
-main
     </Routes>
   )
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,19 +1,12 @@
 import axios from 'axios'
-codex/add-filters-to-timeline-page
 
-import type { Event, GraphData, TimelineEvent } from '../types'
-
-codex/add-get-/graph-api-and-frontend-integration
-import type { Event, GraphData, TimelineEvent } from '../types'
-
- codex/add-crud-functionality-for-notebooks
-import type { Event, GraphData, TimelineEvent, Notebook, NotebookItem } from '../types'
-
-
-import type { Event, GraphData, TimelineEvent } from '../types'
-main
- main
-main
+import type {
+  Event,
+  GraphData,
+  TimelineEvent,
+  Notebook,
+  NotebookItem,
+} from '../types'
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE || '/api',
@@ -24,24 +17,14 @@ export function fetchEvents(types: string) {
   return api.get<Event[]>(`/events?since=48h${typeParam}`)
 }
 
- codex/add-filters-to-timeline-page
-
-codex/add-get-/graph-api-and-frontend-integration
-
- codex/add-crud-functionality-for-notebooks
-
 export function fetchEvent(id: string) {
   return api.get<Event>(`/events/${id}`)
 }
 
- main
-main
- main
 export function fetchGraph(entityId: string) {
   const param = entityId ? `?entity_id=${entityId}` : ''
   return api.get<GraphData>(`/graph${param}`)
 }
- codex/add-filters-to-timeline-page
 
 interface TimelineQuery {
   cursor?: string
@@ -62,13 +45,10 @@ export async function fetchTimelineEvents({
   if (since) params.set('since', since)
   if (types) params.set('type', types)
   const res = await api.get<TimelineEvent[]>(`/events?${params.toString()}`)
-
-export async function fetchTimelineEvents(cursor?: string, limit = 50) {
-  const url = `/events?limit=${limit}${cursor ? `&cursor=${cursor}` : ''}`
-  const res = await api.get<TimelineEvent[]>(url)codex/add-get-/graph-api-and-frontend-integration
-
-codex/add-crud-functionality-for-notebooks
-  return { events: res.data, nextCursor: res.headers['x-next-cursor'] as string | undefined }
+  return {
+    events: res.data,
+    nextCursor: res.headers['x-next-cursor'] as string | undefined,
+  }
 }
 
 export async function fetchNotebooks() {
@@ -98,27 +78,8 @@ export async function removeNotebookItem(notebookId: string, itemId: string) {
   await api.delete(`/notebooks/${notebookId}/items/${itemId}`)
 }
 
-export async function fetchEvent(id: string) {
-  const res = await api.get<Event>(`/events/${id}`)
-  return res.data
-}
-
 export async function fetchEntity(id: string) {
   const res = await api.get(`/entities/${id}`)
   return res.data as any
-
-main
-main
-  return {
-    events: res.data,
-    nextCursor: res.headers['x-next-cursor'] as string | undefined,
-  }
-codex/add-filters-to-timeline-page
-
-codex/add-get-/graph-api-and-frontend-integration
-
-main
-main
-main
 }
 

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { fetchTimelineEvents } from '../lib/api'
-codex/add-filters-to-timeline-page
 import type { EventType, TimelineEvent } from '../types'
+import EventDrawer from '../components/EventDrawer'
 
 const EVENT_TYPES: EventType[] = ['bushfire', 'weather', 'maritime', 'cyber', 'news']
 const TYPE_CHIPS = [
@@ -19,23 +19,16 @@ const RANGES = [
   { value: '30d', label: 'Last 30d' },
 ]
 
-import EventDrawer from '../components/EventDrawer'
-import type { TimelineEvent } from '../types'
-main
-
 export default function TimelinePage() {
   const [events, setEvents] = useState<TimelineEvent[]>([])
   const [cursor, setCursor] = useState<string | undefined>()
   const [loading, setLoading] = useState(false)
-codex/add-filters-to-timeline-page
   const [selectedTypes, setSelectedTypes] = useState<EventType[]>([...EVENT_TYPES])
   const [since, setSince] = useState('48h')
+  const [openId, setOpenId] = useState<string | null>(null)
 
   const typeQuery =
     selectedTypes.length === EVENT_TYPES.length ? undefined : selectedTypes.join('|')
-=======
-  const [openId, setOpenId] = useState<string | null>(null)
-main
 
   const loadMore = (reset = false) => {
     if (loading) return
@@ -118,7 +111,6 @@ main
               borderBottom: '1px solid #ddd',
             }}
           >
-codex/add-filters-to-timeline-page
             <div style={{ width: '12rem', marginRight: '1rem' }}>
               {new Date(ev.detected_at).toLocaleString()}
             </div>
@@ -135,8 +127,15 @@ codex/add-filters-to-timeline-page
             <div style={{ flex: 1 }}>{ev.title}</div>
             <button
               type="button"
-              onClick={() => console.log('Add to Notebook', ev.id)}
+              onClick={() => setOpenId(ev.id)}
               style={{ marginLeft: '1rem' }}
+            >
+              Open
+            </button>
+            <button
+              type="button"
+              onClick={() => console.log('Add to Notebook', ev.id)}
+              style={{ marginLeft: '0.5rem' }}
             >
               Add to Notebook
             </button>
@@ -144,26 +143,6 @@ codex/add-filters-to-timeline-page
         ))
       )}
 
-            {ev.event_type}
-          </span>
-          <div style={{ flex: 1 }}>{ev.title}</div>
-          <button
-            type="button"
-            onClick={() => setOpenId(ev.id)}
-            style={{ marginLeft: '1rem' }}
-          >
-            Open
-          </button>
-          <button
-            type="button"
-            onClick={() => console.log('Add to Notebook', ev.id)}
-            style={{ marginLeft: '0.5rem' }}
-          >
-            Add to Notebook
-          </button>
-        </div>
-      ))}
-main
       {cursor && (
         <div style={{ textAlign: 'center', marginTop: '1rem' }}>
           <button type="button" onClick={() => loadMore()} disabled={loading}>
@@ -175,3 +154,4 @@ main
     </div>
   )
 }
+

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -29,14 +29,7 @@ export interface GraphEdge {
 
 export interface GraphData {
   nodes: GraphNode[]
-codex/add-get-/graph-api-and-frontend-integration
   edges: GraphEdge[]
-
-  links: GraphLink[]
-codex/add-filters-to-timeline-page
-
-main
-main
 }
 
 export interface TimelineEvent {
@@ -44,11 +37,6 @@ export interface TimelineEvent {
   title: string
   event_type: EventType
   detected_at: string
-codex/add-filters-to-timeline-page
-
-codex/add-get-/graph-api-and-frontend-integration
-
-codex/add-crud-functionality-for-notebooks
 }
 
 export interface NotebookItem {
@@ -67,9 +55,5 @@ export interface Notebook {
   title: string
   created_at?: string
   items?: NotebookItem[]
-
-main
-main
-main
 }
 


### PR DESCRIPTION
## Summary
- remove merge artifacts in types and restore proper GraphData, Notebook, and timeline event interfaces
- consolidate API helpers and imports in frontend library
- tidy App routing and resolve timeline page implementation conflicts

## Testing
- `npm test`
- `npm run build`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68b25b6725c4832c95d22906b603467c