### PR TITLE
Use default factory for attrs fields

### DIFF
--- a/ingest/ingest/common/schemas.py
+++ b/ingest/ingest/common/schemas.py
@@ -20,5 +20,5 @@ class NormalizedEvent(BaseModel):
     severity: Optional[float] = None
     lat: Optional[float] = Field(default=None, description="Latitude, WGS84")
     lon: Optional[float] = Field(default=None, description="Longitude, WGS84")
-    attrs: Dict[str, Any] = {}
+    attrs: Dict[str, Any] = Field(default_factory=dict)
 

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -45,7 +45,7 @@ class Entity(BaseModel):
     type: Literal["Person", "Org", "Vessel", "Aircraft", "Location", "Asset", "EventType"]
     name: str
     canonical_key: Optional[str] = None
-    attrs: dict = {}
+    attrs: dict = Field(default_factory=dict)
 
 
 class Notebook(BaseModel):


### PR DESCRIPTION
## Summary
- Use `Field(default_factory=dict)` for schema `attrs` fields to avoid mutable default arguments

## Testing
- `pytest services/api/tests -q` *(fails: ValueError: Duplicated timeseries in CollectorRegistry: {'request_created', 'request_total', 'request'})*


------
https://chatgpt.com/codex/tasks/task_e_68b25b68b0d0832c882feb55d65c66f6